### PR TITLE
Move setupRootAcl from AuthManager to TestSubject

### DIFF
--- a/config/application.yaml
+++ b/config/application.yaml
@@ -19,10 +19,10 @@ quarkus:
         level: DEBUG # to increase overall logging for development
       "org.solid.testharness.http.AuthManager":
         level: INFO # but keep only higher level for authentication
-#"org.solid.testharness.utils":
-#  level: INFO
-#"org.solid.testharness.http.Client":
-#  level: DEBUG
+#      "org.solid.testharness.utils":
+#        level: INFO
+#      "org.solid.testharness.http.Client":
+#        level: DEBUG
 
 # Test profile
 "%test":

--- a/config/config.ttl
+++ b/config/config.ttl
@@ -43,9 +43,9 @@
     a earl:Software, earl:TestSubject ;
     doap:name "Community Solid Server" ;
     doap:release [
-                     doap:name "CSS 0.8.1" ;
-                     doap:revision "0.8.1" ;
-                     doap:created "2021-03-23"^^xsd:date
+                     doap:name "CSS 0.9.0" ;
+                     doap:revision "0.9.0" ;
+                     doap:created "2021-05-04"^^xsd:date
                  ] ;
     doap:developer <https://github.com/solid> ;
     doap:homepage <https://github.com/solid/community-server> ;

--- a/src/main/java/org/solid/testharness/ConformanceTestHarness.java
+++ b/src/main/java/org/solid/testharness/ConformanceTestHarness.java
@@ -129,6 +129,7 @@ public class ConformanceTestHarness {
             }
 
             testSubject.registerClients();
+            testSubject.prepareServer();
         } catch (TestHarnessInitializationException e) {
             logger.error("Cannot run test suites", e);
             return null;

--- a/src/main/java/org/solid/testharness/config/TestSubject.java
+++ b/src/main/java/org/solid/testharness/config/TestSubject.java
@@ -9,6 +9,7 @@ import org.slf4j.LoggerFactory;
 import org.solid.common.vocab.EARL;
 import org.solid.common.vocab.RDF;
 import org.solid.testharness.http.AuthManager;
+import org.solid.testharness.http.HttpConstants;
 import org.solid.testharness.http.SolidClient;
 import org.solid.testharness.utils.DataRepository;
 import org.solid.testharness.utils.TestHarnessInitializationException;
@@ -18,9 +19,12 @@ import javax.inject.Inject;
 import javax.validation.constraints.NotNull;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
 
 @ApplicationScoped
 public class TestSubject {
@@ -85,6 +89,41 @@ public class TestSubject {
                         conn.add(model.filter((BNode) value, null, null));
                     }
                 }
+            }
+        }
+    }
+
+    public void prepareServer() {
+        if (targetServer == null) {
+            throw new TestHarnessInitializationException("No target server has been configured");
+        }
+        if (targetServer.isSetupRootAcl()) {
+            // CSS has no root acl by default so added here TODO: check whether this is relevant
+            logger.debug("Setup root acl");
+            final SolidClient solidClient = new SolidClient(HttpConstants.ALICE);
+            final String webId = requireNonNull(targetServer.getUsers().get(HttpConstants.ALICE).getWebID(),
+                    "Alice's webID is required");
+
+            try {
+                final URI rootAclUrl = solidClient.getResourceAclLink(
+                        targetServer.getServerRoot() + (targetServer.getServerRoot().endsWith("/") ? "" : "/")
+                );
+                if (rootAclUrl == null) {
+                    throw new TestHarnessInitializationException("Failed getting the root ACL link");
+                }
+                final String acl = String.format("@prefix acl: <http://www.w3.org/ns/auth/acl#>. " +
+                        "<#alice> a acl:Authorization ; " +
+                        "  acl:agent <%s> ;" +
+                        "  acl:accessTo <./>;" +
+                        "  acl:default <./>;" +
+                        "  acl:mode acl:Read, acl:Write, acl:Control .", webId);
+                if (!solidClient.createAcl(rootAclUrl, acl)) {
+                    throw new TestHarnessInitializationException("Failed to create root ACL");
+                }
+            } catch (IOException | InterruptedException e) {
+                throw (TestHarnessInitializationException) new TestHarnessInitializationException(
+                        "Failed to create root ACL: %s", e.toString()
+                ).initCause(e);
             }
         }
     }

--- a/src/main/java/org/solid/testharness/config/TestSubject.java
+++ b/src/main/java/org/solid/testharness/config/TestSubject.java
@@ -149,6 +149,10 @@ public class TestSubject {
         return targetServer;
     }
 
+    public void setTargetServer(final TargetServer targetServer) {
+        this.targetServer = targetServer;
+    }
+
     public Map<String, SolidClient> getClients() {
         return clients;
     }

--- a/src/main/java/org/solid/testharness/http/AuthManager.java
+++ b/src/main/java/org/solid/testharness/http/AuthManager.java
@@ -7,6 +7,7 @@ import org.solid.testharness.config.TargetServer;
 import org.solid.testharness.config.UserCredentials;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
 import java.net.URI;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
@@ -17,6 +18,9 @@ import java.util.stream.Collectors;
 public class AuthManager {
     private static final Logger logger = LoggerFactory.getLogger(AuthManager.class);
 
+    @Inject
+    ClientRegistry clientRegistry;
+
     private ObjectMapper objectMapper = new ObjectMapper();
 
     public SolidClient authenticate(final String user, final TargetServer targetServer) throws Exception {
@@ -25,8 +29,8 @@ public class AuthManager {
         }
         final UserCredentials userConfig = targetServer.getUsers().get(user);
         final Client authClient;
-        if (ClientRegistry.hasClient(user)) {
-            authClient = ClientRegistry.getClient(user);
+        if (clientRegistry.hasClient(user)) {
+            authClient = clientRegistry.getClient(user);
         } else {
             logger.debug("Build new client for {}", user);
             final Client.Builder builder = new Client.Builder(user);
@@ -37,7 +41,7 @@ public class AuthManager {
                 builder.withLocalhostSupport();
             }
             authClient = builder.build();
-            ClientRegistry.register(user, authClient);
+            clientRegistry.register(user, authClient);
 
             final Tokens tokens;
             if (userConfig.isUsingUsernamePassword()) {
@@ -52,14 +56,7 @@ public class AuthManager {
             logger.debug("access_token ({}) {}", user, accessToken);
             authClient.setAccessToken(accessToken);
         }
-
-        final SolidClient solidClient = new SolidClient(authClient);
-        if (HttpConstants.ALICE.equals(user) && targetServer.isSetupRootAcl()) {
-            logger.debug("**** Setup root acl");
-            // CSS has no root acl by default so added here TODO: check whether this is relevant
-            solidClient.setupRootAcl(targetServer.getServerRoot(), userConfig.getWebID());
-        }
-        return solidClient;
+        return new SolidClient(authClient);
     }
 
     private Tokens exchangeRefreshToken(final Client authClient, final UserCredentials userConfig,
@@ -99,7 +96,7 @@ public class AuthManager {
         final String solidIdentityProvider = config.getSolidIdentityProvider();
         final String appOrigin = config.getOrigin();
         logger.info("Login and get access token at {} for {}", solidIdentityProvider, authClient.getUser());
-        final Client client = ClientRegistry.getClient(ClientRegistry.SESSION_BASED);
+        final Client client = clientRegistry.getClient(ClientRegistry.SESSION_BASED);
         final URI uri = URI.create(solidIdentityProvider);
 
         final Map<Object, Object> data = new HashMap<>();

--- a/src/main/java/org/solid/testharness/http/ClientRegistry.java
+++ b/src/main/java/org/solid/testharness/http/ClientRegistry.java
@@ -1,32 +1,37 @@
 package org.solid.testharness.http;
 
-import java.util.*;
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
-public final class ClientRegistry {
-    private static final Map<String, Client> registeredClientMap = Collections.synchronizedMap(new HashMap<>());
+@ApplicationScoped
+public class ClientRegistry {
+    private Map<String, Client> registeredClientMap;
 
     public static final String DEFAULT = "default";
     public static final String SESSION_BASED = "session";
 
-    static {
+    @PostConstruct
+    void postConstruct() {
+        registeredClientMap = Collections.synchronizedMap(new HashMap<>());
         register(DEFAULT, new Client.Builder().build());
         register(SESSION_BASED, new Client.Builder().withSessionSupport().build());
     }
 
-    public static void register(final String label, final Client client) {
+    public void register(final String label, final Client client) {
         registeredClientMap.put(label, client);
     }
 
-    public static boolean hasClient(final String label) {
+    public boolean hasClient(final String label) {
         return registeredClientMap.containsKey(label);
     }
 
-    public static Client getClient(final String label) {
+    public Client getClient(final String label) {
         if (label == null) {
             return registeredClientMap.get(DEFAULT);
         }
         return registeredClientMap.get(label);
     }
-
-    private ClientRegistry() { }
 }

--- a/src/test/java/TestScenarioRunner.java
+++ b/src/test/java/TestScenarioRunner.java
@@ -24,8 +24,9 @@ public class TestScenarioRunner {
     void testScenario() {
         testSubject.loadTestSubjectConfig();
         testSubject.registerClients();
-//        String featurePath = "content-negotiation/content-negotiation-turtle.feature";
-        final String featurePath = "example/writing-resource/containment.feature";
+        testSubject.prepareServer();
+        final String featurePath = "example/content-negotiation/content-negotiation-turtle.feature";
+//        final String featurePath = "example/writing-resource/containment.feature";
         final String uri = Path.of(featurePath).toAbsolutePath().normalize().toUri().toString();
         final TestSuiteResults results = testRunner.runTest(uri);
         assertNotNull(results);

--- a/src/test/java/TestSuiteRunner.java
+++ b/src/test/java/TestSuiteRunner.java
@@ -10,6 +10,7 @@ import org.solid.testharness.utils.DataRepository;
 
 import javax.inject.Inject;
 import java.io.File;
+import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -32,7 +33,8 @@ public class TestSuiteRunner {
     }
 
     @Test
-    void testSuite() {
+    void testSuite() throws IOException {
+        conformanceTestHarness.initialize();
         final TestSuiteResults results = conformanceTestHarness.runTestSuites();
         assertNotNull(results);
         assertEquals(0, results.getFailCount(), results.getErrorMessages());

--- a/src/test/java/org/solid/testharness/config/TestSubjectSetupTest.java
+++ b/src/test/java/org/solid/testharness/config/TestSubjectSetupTest.java
@@ -10,10 +10,8 @@ import javax.inject.Inject;
 import java.net.MalformedURLException;
 
 import static org.eclipse.rdf4j.model.util.Values.iri;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 @QuarkusTest
 public class TestSubjectSetupTest {
@@ -70,11 +68,13 @@ public class TestSubjectSetupTest {
 
     @Test
     void prepareServerWithoutServer() {
+        testSubject.setTargetServer(null);
         assertThrows(TestHarnessInitializationException.class, () -> testSubject.prepareServer());
     }
 
     @Test
     void registerWithoutServer() {
+        testSubject.setTargetServer(null);
         assertThrows(TestHarnessInitializationException.class, () -> testSubject.registerClients());
     }
 }

--- a/src/test/java/org/solid/testharness/config/TestSubjectSetupTest.java
+++ b/src/test/java/org/solid/testharness/config/TestSubjectSetupTest.java
@@ -69,6 +69,11 @@ public class TestSubjectSetupTest {
     }
 
     @Test
+    void prepareServerWithoutServer() {
+        assertThrows(TestHarnessInitializationException.class, () -> testSubject.prepareServer());
+    }
+
+    @Test
     void registerWithoutServer() {
         assertThrows(TestHarnessInitializationException.class, () -> testSubject.registerClients());
     }

--- a/src/test/java/org/solid/testharness/config/TestSubjectTest.java
+++ b/src/test/java/org/solid/testharness/config/TestSubjectTest.java
@@ -16,18 +16,9 @@ import java.util.List;
 import java.util.Map;
 
 import static org.eclipse.rdf4j.model.util.Values.iri;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
 @QuarkusTest
 public class TestSubjectTest {
@@ -197,6 +188,14 @@ public class TestSubjectTest {
         final TargetServer targetServer = testSubject.getTargetServer();
         assertNotNull(targetServer);
         assertEquals("https://github.com/solid/conformance-test-harness/testserver2", targetServer.getSubject());
+    }
+
+    @Test
+    void setTargetServer() {
+        final TargetServer targetServer = mock(TargetServer.class);
+        when(targetServer.getServerRoot()).thenReturn("SERVER_ROOT");
+        testSubject.setTargetServer(targetServer);
+        assertEquals("SERVER_ROOT", testSubject.getTargetServer().getServerRoot());
     }
 
     @Test

--- a/src/test/resources/config-sample-bad.ttl
+++ b/src/test/resources/config-sample-bad.ttl
@@ -23,5 +23,5 @@
                              solid-test:webId <https://example.org/webid> ;
                              solid-test:credentials "inrupt-alice.json"
                          ] ;
-    solid-test:serverRoot <http://localhost> ;
+    solid-test:serverRoot <http://localhost/> ;
     solid-test:setupRootAcl true .

--- a/src/test/resources/config-sample-bad.ttl
+++ b/src/test/resources/config-sample-bad.ttl
@@ -1,0 +1,27 @@
+@base <https://github.com/solid/conformance-test-harness/> .
+@prefix solid-test: <https://github.com/solid/conformance-test-harness/vocab#> .
+
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix doap: <http://usefulinc.com/ns/doap#> .
+@prefix earl: <http://www.w3.org/ns/earl#> .
+@prefix solid: <http://www.w3.org/ns/solid/terms#> .
+
+<bad-users>
+    a earl:Software, earl:TestSubject ;
+    doap:name "Bad server" ;
+    solid-test:aliceUser [
+                             solid-test:credentials "inrupt-alice.json"
+                         ] ;
+    solid-test:setupRootAcl true .
+
+<example>
+    a earl:Software, earl:TestSubject ;
+    doap:name "Example server" ;
+    solid-test:aliceUser [
+                             solid-test:webId <https://example.org/webid> ;
+                             solid-test:credentials "inrupt-alice.json"
+                         ] ;
+    solid-test:serverRoot <http://localhost> ;
+    solid-test:setupRootAcl true .


### PR DESCRIPTION
This is a small refactor to move a function to a more appropriate location. It also involved converting the static ClientRegistry class to an ApplicationScoped bean which simplified testing.