### PR TITLE
Move test RDF into resource files

### DIFF
--- a/src/test/java/org/solid/testharness/config/TargetServerTest.java
+++ b/src/test/java/org/solid/testharness/config/TargetServerTest.java
@@ -6,9 +6,11 @@ import org.junit.jupiter.api.Test;
 import org.solid.testharness.http.HttpConstants;
 import org.solid.testharness.utils.DataRepository;
 import org.solid.testharness.utils.TestData;
+import org.solid.testharness.utils.TestUtils;
 
 import javax.inject.Inject;
 import java.io.StringReader;
+import java.net.URL;
 
 import static org.eclipse.rdf4j.model.util.Values.iri;
 import static org.junit.jupiter.api.Assertions.*;
@@ -23,32 +25,8 @@ public class TargetServerTest {
 
     @Test
     public void parseTargetServer() throws Exception {
-        final StringReader reader = new StringReader(TestData.PREFIXES +
-                "ex:testserver\n" +
-                "    a earl:Software, earl:TestSubject ;\n" +
-                "    doap:name \"Enterprise Solid Server (Web Access Control version)\";\n" +
-                "    doap:release [\n" +
-                "        doap:name \"ESS 1.0.9\";\n" +
-                "        doap:revision \"1.0.9\";\n" +
-                "        doap:created \"2021-03-05\"^^xsd:date\n" +
-                "    ];\n" +
-                "    doap:developer <https://inrupt.com/profile/card/#us>;\n" +
-                "    doap:homepage <https://inrupt.com/products/enterprise-solid-server>;\n" +
-                "    doap:description \"A production-grade Solid server produced and supported by Inrupt.\"@en;\n" +
-                "    doap:programming-language \"Java\" ;\n" +
-                "    solid:oidcIssuer <https://inrupt.net> ;\n" +
-                "    solid:loginEndpoint <https://inrupt.net/login/password> ;\n" +
-                "    solid-test:origin <https://tester> ;\n" +
-                "    solid-test:aliceUser <https://solid-test-suite-alice.inrupt.net/profile/card#me> ;\n" +
-                "    solid-test:bobUser <https://solid-test-suite-bob.inrupt.net/profile/card#me> ;\n" +
-                "    solid-test:maxThreads 4 ;\n" +
-                "    solid-test:features \"feature1\" ;\n" +
-                "    solid-test:serverRoot <http://localhost:3000> ;\n" +
-                "    solid-test:podRoot <http://localhost:3000/> ;\n" +
-                "    solid-test:testContainer \"/test/\" ;\n" +
-//                "    solid-test:disableDPoP true ;\n" +
-                "    solid-test:setupRootAcl true .");
-        TestData.insertData(dataRepository, reader);
+        final URL testFile = TestUtils.getFileUrl("src/test/resources/targetserver-testing-feature.ttl");
+        TestData.insertData(dataRepository, testFile);
         final TargetServer targetServer = new TargetServer(iri(TestData.SAMPLE_NS, "testserver"));
         assertAll("targetServer",
                 () -> assertNotNull(targetServer.getFeatures()),

--- a/src/test/java/org/solid/testharness/reporting/AssertionTest.java
+++ b/src/test/java/org/solid/testharness/reporting/AssertionTest.java
@@ -13,15 +13,8 @@ import static org.junit.jupiter.api.Assertions.*;
 @QuarkusTest
 class AssertionTest extends AbstractDataModelTests {
     @Override
-    public String getData() {
-        return TestData.PREFIXES + "ex:assertion1 a earl:Assertion;\n" +
-                "    earl:assertedBy " + Namespaces.TEST_HARNESS_PREFIX + ":;\n" +
-                "    earl:test ex:test;\n" +
-                "    earl:subject " + Namespaces.TEST_HARNESS_PREFIX + ":testserver;\n" +
-                "    earl:mode earl:automatic;\n" +
-                "    earl:result ex:result1 .\n" +
-                "ex:result1 a earl:TestResult.\n" +
-                "ex:assertion2 a earl:Assertion.";
+    public String getTestFile() {
+        return "src/test/resources/assertiontest-testing-feature.ttl";
     }
 
     @Test

--- a/src/test/java/org/solid/testharness/reporting/ResultDataTest.java
+++ b/src/test/java/org/solid/testharness/reporting/ResultDataTest.java
@@ -13,16 +13,12 @@ import static org.junit.jupiter.api.Assertions.*;
 @QuarkusTest
 class ResultDataTest extends AbstractDataModelTests {
     @Override
-    public String getData() {
-        return TestData.PREFIXES +
-                "<" + TestData.SAMPLE_NS + "> doap:implements <https://solidproject.org/TR/protocol#spec1> ;\n" +
-                "  dcterms:hasPart ex:test1, ex:test2 .\n" +
-                "ex:test1 a td:SpecificationTestCase .\n" +
-                "ex:test2 a td:SpecificationTestCase .";
+    public String getTestFile() {
+        return "src/test/resources/resultdata-testing-feature.ttl";
     }
 
     @Test
-    void getPrefixes() {
+    void getHtmlPrefixes() {
         final ResultData resultData = new ResultData(iri(TestData.SAMPLE_NS));
         assertEquals("rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns# " +
                 "rdfs: http://www.w3.org/2000/01/rdf-schema# " +

--- a/src/test/java/org/solid/testharness/reporting/ScenarioTest.java
+++ b/src/test/java/org/solid/testharness/reporting/ScenarioTest.java
@@ -11,23 +11,8 @@ import static org.junit.jupiter.api.Assertions.*;
 @QuarkusTest
 class ScenarioTest extends AbstractDataModelTests {
     @Override
-    public String getData() {
-        return TestData.PREFIXES + "ex:scenario1 a earl:TestCriterion, earl:TestCase;\n" +
-                "    dcterms:title \"TITLE\";\n" +
-                "    dcterms:isPartOf ex:parent;\n" +
-                "    earl:assertions ex:assertion;\n" +
-                "    earl:steps ex:steps .\n" +
-                "ex:assertion a earl:Assertion .\n" +
-                "ex:steps a rdf:List;\n" +
-                "    rdf:first ex:step1;\n" +
-                "    rdf:rest (ex:step2).\n" +
-                "ex:step1 a earl:TestStep;\n" +
-                "    dcterms:title \"STEP1\";\n" +
-                "    earl:outcome earl:passed .\n" +
-                "ex:step2 a earl:TestStep;\n" +
-                "    dcterms:title \"STEP2\";\n" +
-                "    earl:outcome earl:passed .\n" +
-                "ex:scenario2 a earl:TestCriterion, earl:TestCase.\n";
+    public String getTestFile() {
+        return "src/test/resources/scenario-testing-feature.ttl";
     }
 
     @Test

--- a/src/test/java/org/solid/testharness/reporting/SpecificationTestCaseTest.java
+++ b/src/test/java/org/solid/testharness/reporting/SpecificationTestCaseTest.java
@@ -3,7 +3,6 @@ package org.solid.testharness.reporting;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
 import org.solid.testharness.utils.AbstractDataModelTests;
-import org.solid.testharness.utils.TestData;
 
 import java.util.List;
 
@@ -13,19 +12,8 @@ import static org.junit.jupiter.api.Assertions.*;
 @QuarkusTest
 class SpecificationTestCaseTest extends AbstractDataModelTests {
     @Override
-    public String getData() {
-        return TestData.PREFIXES +
-                "ex:test1\n" +
-                "    a td:SpecificationTestCase ;\n" +
-                "    dcterms:title \"Title\" ;\n" +
-                "    dcterms:description \"Description\" ;\n" +
-                "    td:specificationReference ex:spec ;\n" +
-                "    dcterms:hasPart ex:testcase ." +
-                "ex:testcase\n" +
-                "    a earl:TestCase ;\n" +
-                "    td:reviewStatus td:accepted .\n" +
-                "ex:test2\n" +
-                "    a td:SpecificationTestCase .";
+    public String getTestFile() {
+        return "src/test/resources/specificationtestcase-testing-feature.ttl";
     }
 
     @Test

--- a/src/test/java/org/solid/testharness/reporting/TestCaseTest.java
+++ b/src/test/java/org/solid/testharness/reporting/TestCaseTest.java
@@ -4,7 +4,6 @@ import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
 import org.solid.common.vocab.EARL;
 import org.solid.testharness.utils.AbstractDataModelTests;
-import org.solid.testharness.utils.TestData;
 
 import static org.eclipse.rdf4j.model.util.Values.iri;
 import static org.junit.jupiter.api.Assertions.*;
@@ -12,25 +11,8 @@ import static org.junit.jupiter.api.Assertions.*;
 @QuarkusTest
 class TestCaseTest extends AbstractDataModelTests  {
     @Override
-    public String getData() {
-        return TestData.PREFIXES +
-                "ex:test1\n" +
-                "    a earl:TestCase, earl:TestCriterion, earl:TestFeature ;\n" +
-                "    dcterms:title \"Title\" ;\n" +
-                "    dcterms:subject \"MUST\" ;\n" +
-                "    td:reviewStatus td:unreviewed ;\n" +
-                "    earl:hasOutcome \"TBD\" ;\n" +
-                "    earl:assertions ex:assertion ;\n" +
-                "    dcterms:hasPart ex:test3 .\n" +
-                "ex:assertion a earl:Assertion .\n" +
-                "ex:test2\n" +
-                "    a earl:TestCase ;\n" +
-                "    td:reviewStatus td:accepted ;\n" +
-                "    earl:mode earl:untested .\n" +
-                "ex:test3\n" +
-                "    a earl:TestCase ;\n" +
-                "    earl:mode earl:passed .";
-
+    public String getTestFile() {
+        return "src/test/resources/testcase-testing-feature.ttl";
     }
 
     @Test

--- a/src/test/java/org/solid/testharness/utils/AbstractDataModelTests.java
+++ b/src/test/java/org/solid/testharness/utils/AbstractDataModelTests.java
@@ -5,20 +5,23 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
 
 import java.io.IOException;
-import java.io.StringReader;
+import java.io.Reader;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class AbstractDataModelTests {
     protected static String NS = TestData.SAMPLE_NS;
 
-    public abstract String getData();
+    public abstract String getTestFile();
 
     @BeforeAll
     void setup() throws IOException {
-        final StringReader reader = new StringReader(getData());
-        final DataRepository repository = new DataRepository();
-        repository.postConstruct();
-        TestData.insertData(repository, reader);
-        QuarkusMock.installMockForType(repository, DataRepository.class);
+        try (Reader reader = Files.newBufferedReader(Path.of(getTestFile()))) {
+            final DataRepository repository = new DataRepository();
+            repository.postConstruct();
+            TestData.insertData(repository, reader);
+            QuarkusMock.installMockForType(repository, DataRepository.class);
+        }
     }
 }

--- a/src/test/java/org/solid/testharness/utils/DataModelBaseTest.java
+++ b/src/test/java/org/solid/testharness/utils/DataModelBaseTest.java
@@ -28,23 +28,9 @@ class DataModelBaseTest extends AbstractDataModelTests {
     }
 
     @Override
-    public String getData() {
-        return TestData.PREFIXES +
-                "ex:test\n" +
-                "    a earl:Software, earl:TestSubject ;\n" +
-                "    ex:hasIri ex:iri ;\n" +
-                "    ex:hasString \"string\" ;\n" +
-                "    ex:hasStrings \"string1\", \"string2\" ;\n" +
-                "    ex:hasInt 1 ;\n" +
-                "    ex:hasBool true ;" +
-                "    ex:hasDate \"2021-04-08\"^^xsd:date ;\n" +
-                "    ex:hasDateTime \"2021-04-08T12:30:00.000\"^^xsd:dateTime ;\n" +
-                "    ex:hasBNode [ ex:hasString \"string\" ];\n" +
-                "    ex:hasTest ex:test1 ;\n" +
-                "    ex:hasSteps (ex:step1 ex:step2) .\n" +
-                "ex:test1 a earl:TestCase .\n" +
-                "ex:step1 a earl:Step .\n" +
-                "ex:step2 a earl:Step .";
+    public String getTestFile() {
+        return "src/test/resources/datamodelbase-testing-feature.ttl";
+
     }
 
     @Test

--- a/src/test/java/org/solid/testharness/utils/TestData.java
+++ b/src/test/java/org/solid/testharness/utils/TestData.java
@@ -9,6 +9,7 @@ import org.solid.common.vocab.RDF;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
+import java.net.URL;
 
 import static org.eclipse.rdf4j.model.util.Values.iri;
 
@@ -42,6 +43,12 @@ public final class TestData {
     public static void insertData(final DataRepository dataRepository, final Reader reader) throws IOException {
         try (RepositoryConnection conn = dataRepository.getConnection()) {
             conn.add(reader, RDFFormat.TURTLE);
+        }
+    }
+
+    public static void insertData(final DataRepository dataRepository, final URL url) throws IOException {
+        try (RepositoryConnection conn = dataRepository.getConnection()) {
+            conn.add(url, RDFFormat.TURTLE);
         }
     }
 

--- a/src/test/resources/assertiontest-testing-feature.ttl
+++ b/src/test/resources/assertiontest-testing-feature.ttl
@@ -1,0 +1,13 @@
+@prefix td: <http://www.w3.org/2006/03/test-description#> .
+@prefix test-harness: <https://github.com/solid/conformance-test-harness/> .
+@prefix earl: <http://www.w3.org/ns/earl#> .
+@prefix ex: <https://example.org/> .
+
+ex:assertion1 a earl:Assertion ;
+    earl:assertedBy test-harness: ;
+    earl:test ex:test;
+    earl:subject test-harness:testserver;
+    earl:mode earl:automatic;
+    earl:result ex:result1 .
+ex:result1 a earl:TestResult.
+ex:assertion2 a earl:Assertion.

--- a/src/test/resources/config-sample-bad.ttl
+++ b/src/test/resources/config-sample-bad.ttl
@@ -11,17 +11,11 @@
 <bad-users>
     a earl:Software, earl:TestSubject ;
     doap:name "Bad server" ;
-    solid-test:aliceUser [
-                             solid-test:credentials "inrupt-alice.json"
-                         ] ;
     solid-test:setupRootAcl true .
 
 <example>
     a earl:Software, earl:TestSubject ;
     doap:name "Example server" ;
-    solid-test:aliceUser [
-                             solid-test:webId <https://example.org/webid> ;
-                             solid-test:credentials "inrupt-alice.json"
-                         ] ;
+    solid-test:aliceUser <https://example.org/webid> ;
     solid-test:serverRoot <http://localhost/> ;
     solid-test:setupRootAcl true .

--- a/src/test/resources/datamodelbase-testing-feature.ttl
+++ b/src/test/resources/datamodelbase-testing-feature.ttl
@@ -1,0 +1,19 @@
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix earl: <http://www.w3.org/ns/earl#> .
+@prefix ex: <https://example.org/> .
+
+ex:test
+    a earl:Software, earl:TestSubject ;
+    ex:hasIri ex:iri ;
+    ex:hasString "string" ;
+    ex:hasStrings "string1", "string2" ;
+    ex:hasInt 1 ;
+    ex:hasBool true ;
+    ex:hasDate "2021-04-08"^^xsd:date ;
+    ex:hasDateTime "2021-04-08T12:30:00.000"^^xsd:dateTime ;
+    ex:hasBNode [ ex:hasString "string" ];
+    ex:hasTest ex:test1 ;
+    ex:hasSteps (ex:step1 ex:step2) .
+ex:test1 a earl:TestCase .
+ex:step1 a earl:Step .
+ex:step2 a earl:Step .

--- a/src/test/resources/resultdata-prefixes-testing-feature.ttl
+++ b/src/test/resources/resultdata-prefixes-testing-feature.ttl
@@ -1,0 +1,14 @@
+@prefix td: <http://www.w3.org/2006/03/test-description#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix doap: <http://usefulinc.com/ns/doap#> .
+@prefix ex: <https://example.org/> .
+
+"rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns# " +
+                                                    "rdfs: http://www.w3.org/2000/01/rdf-schema# " +
+                                                    "xsd: http://www.w3.org/2001/XMLSchema# " +
+                                                    "dcterms: http://purl.org/dc/terms/ " +
+                                                    "doap: http://usefulinc.com/ns/doap# " +
+                                                    "solid: http://www.w3.org/ns/solid/terms# " +
+                                                                                                "solid-test: https://github.com/solid/conformance-test-harness/vocab# " +
+                                                                                                "earl: http://www.w3.org/ns/earl# " +
+                                                                                                "td: http://www.w3.org/2006/03/test-description#

--- a/src/test/resources/resultdata-testing-feature.ttl
+++ b/src/test/resources/resultdata-testing-feature.ttl
@@ -1,0 +1,9 @@
+@prefix td: <http://www.w3.org/2006/03/test-description#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix doap: <http://usefulinc.com/ns/doap#> .
+@prefix ex: <https://example.org/> .
+
+ex: doap:implements <https://solidproject.org/TR/protocol#spec1> ;
+    dcterms:hasPart ex:test1, ex:test2 .
+ex:test1 a td:SpecificationTestCase .
+ex:test2 a td:SpecificationTestCase .

--- a/src/test/resources/scenario-testing-feature.ttl
+++ b/src/test/resources/scenario-testing-feature.ttl
@@ -1,0 +1,21 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix earl: <http://www.w3.org/ns/earl#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix ex: <https://example.org/> .
+
+ex:scenario1 a earl:TestCriterion, earl:TestCase;
+    dcterms:title "TITLE";
+    dcterms:isPartOf ex:parent;
+    earl:assertions ex:assertion;
+    earl:steps ex:steps .
+ex:assertion a earl:Assertion .
+ex:steps a rdf:List;
+    rdf:first ex:step1;
+    rdf:rest (ex:step2).
+ex:step1 a earl:TestStep;
+    dcterms:title "STEP1";
+    earl:outcome earl:passed .
+ex:step2 a earl:TestStep;
+    dcterms:title "STEP2";
+    earl:outcome earl:passed .
+ex:scenario2 a earl:TestCriterion, earl:TestCase.

--- a/src/test/resources/specificationtestcase-testing-feature.ttl
+++ b/src/test/resources/specificationtestcase-testing-feature.ttl
@@ -1,0 +1,16 @@
+@prefix td: <http://www.w3.org/2006/03/test-description#> .
+@prefix earl: <http://www.w3.org/ns/earl#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix ex: <https://example.org/> .
+
+ex:test1
+    a td:SpecificationTestCase ;
+    dcterms:title "Title" ;
+    dcterms:description "Description" ;
+    td:specificationReference ex:spec ;
+    dcterms:hasPart ex:testcase .
+ex:testcase
+    a earl:TestCase ;
+    td:reviewStatus td:accepted .
+ex:test2
+    a td:SpecificationTestCase .

--- a/src/test/resources/targetserver-testing-feature.ttl
+++ b/src/test/resources/targetserver-testing-feature.ttl
@@ -1,0 +1,31 @@
+@prefix solid-test: <https://github.com/solid/conformance-test-harness/vocab#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix earl: <http://www.w3.org/ns/earl#> .
+@prefix doap: <http://usefulinc.com/ns/doap#> .
+@prefix solid: <http://www.w3.org/ns/solid/terms#> .
+@prefix ex: <https://example.org/> .
+
+ex:testserver
+    a earl:Software, earl:TestSubject ;
+    doap:name "Enterprise Solid Server (Web Access Control version)";
+    doap:release [
+        doap:name "ESS 1.0.9";
+        doap:revision "1.0.9";
+        doap:created "2021-03-05"^^xsd:date
+    ];
+    doap:developer <https://inrupt.com/profile/card/#us>;
+    doap:homepage <https://inrupt.com/products/enterprise-solid-server>;
+    doap:description "A production-grade Solid server produced and supported by Inrupt."@en;
+    doap:programming-language "Java" ;
+    solid:oidcIssuer <https://inrupt.net> ;
+    solid:loginEndpoint <https://inrupt.net/login/password> ;
+    solid-test:origin <https://tester> ;
+    solid-test:aliceUser <https://solid-test-suite-alice.inrupt.net/profile/card#me> ;
+    solid-test:bobUser <https://solid-test-suite-bob.inrupt.net/profile/card#me> ;
+    solid-test:maxThreads 4 ;
+    solid-test:features "feature1" ;
+    solid-test:serverRoot <http://localhost:3000> ;
+    solid-test:podRoot <http://localhost:3000/> ;
+    solid-test:testContainer "/test/" ;
+#    solid-test:disableDPoP true ;
+    solid-test:setupRootAcl true .

--- a/src/test/resources/testcase-testing-feature.ttl
+++ b/src/test/resources/testcase-testing-feature.ttl
@@ -1,0 +1,23 @@
+@prefix td: <http://www.w3.org/2006/03/test-description#> .
+@prefix earl: <http://www.w3.org/ns/earl#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix ex: <https://example.org/> .
+
+ex:test1
+    a earl:TestCase, earl:TestCriterion, earl:TestFeature ;
+    dcterms:title "Title" ;
+    dcterms:subject "MUST" ;
+    td:reviewStatus td:unreviewed ;
+    earl:hasOutcome "TBD" ;
+    earl:assertions ex:assertion ;
+    dcterms:hasPart ex:test3 .
+ex:assertion a earl:Assertion .
+ex:test2
+    a earl:TestCase ;
+    td:reviewStatus td:accepted ;
+    earl:mode earl:untested .
+ex:test3
+    a earl:TestCase ;
+    earl:mode earl:passed .
+
+


### PR DESCRIPTION
As suggested in a previous PR, the RDF used in tests has been extracted to separate files making them more readable. The only files changed in this PR are tests so a quick review should suffice.