### PR TITLE
Move credentials into main config and implement http package tests

### DIFF
--- a/config/application.yaml
+++ b/config/application.yaml
@@ -36,12 +36,6 @@ quarkus:
         path: src/test/resources/dummy-features/otherExample
       - prefix: https://example.org/features
         path: src/test/resources
-  solidIdentityProvider: https://idp.example.org
-  loginEndpoint: https://example.org/login/password
-  serverRoot: https://target.example.org
-  testContainer: test
-  aliceWebId: https://alice.target.example.org/profile/card#me
-  bobWebId: https://bob.target.example.org/profile/card#me
 
   quarkus:
     log:
@@ -56,11 +50,6 @@ quarkus:
   feature:
     mappings:
       - null
-  solidIdentityProvider: notnull
-  serverRoot: notnull
-  testContainer: notnull
-  aliceWebId: notnull
-  bobWebId: notnull
   quarkus:
     log:
       category:

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
         <commons.cli.version>1.4</commons.cli.version>
         <mockito.version>3.10.0</mockito.version>
         <jandex.version>2.2.3.Final</jandex.version>
+        <wiremock.version>2.27.2</wiremock.version>
 
         <!-- package info -->
         <package.name>${project.name}</package.name>
@@ -235,6 +236,11 @@
             <version>${jandex.version}</version>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock</artifactId>
+            <version>${wiremock.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <finalName>solid-conformance-test-harness</finalName>
@@ -324,13 +330,14 @@
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>${jacoco-plugin.version}</version>
-                <!-- This can be used to exclude a class from coverage if needed
                 <configuration>
                     <excludes>
-                        <exclude>**/ReportGenerator.*</exclude>
+                        <!-- class not tested as it is not possible to simulate the exceptions -->
+                        <exclude>**/JwsUtils.*</exclude>
+                        <exclude>**/LocalHostSupport.*</exclude>
+                        <exclude>**/LocalHostSupport$*.*</exclude>
                     </excludes>
                 </configuration>
-                -->
                 <executions>
                     <execution>
                         <goals>
@@ -343,6 +350,31 @@
                         <goals>
                             <goal>report</goal>
                         </goals>
+                    </execution>
+                    <execution>
+                        <id>jacoco-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule>
+                                    <element>PACKAGE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.90</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.98</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/src/main/java/org/solid/testharness/config/Config.java
+++ b/src/main/java/org/solid/testharness/config/Config.java
@@ -1,9 +1,11 @@
 package org.solid.testharness.config;
 
+import io.quarkus.arc.config.ConfigPrefix;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.rdf4j.model.IRI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.solid.testharness.http.HttpConstants;
 import org.solid.testharness.utils.TestHarnessInitializationException;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -54,6 +56,12 @@ public class Config {
     String aliceWebId;
     @ConfigProperty(name = "BOB_WEBID")
     String bobWebId;
+
+    @Inject
+    UserCredentials aliceCredentials;
+
+    @ConfigPrefix("bob")
+    UserCredentials bobCredentials;
 
     @Inject
     PathMappings pathMappings;
@@ -115,7 +123,7 @@ public class Config {
     }
 
     public URI getSolidIdentityProvider() {
-        return URI.create(solidIdentityProvider);
+        return URI.create(solidIdentityProvider).resolve("/");
     }
 
     public URI getLoginEndpoint() {
@@ -139,6 +147,17 @@ public class Config {
 
     public String getBobWebId() {
         return bobWebId;
+    }
+
+    public UserCredentials getCredentials(final String user) {
+        switch (user) {
+            case HttpConstants.ALICE:
+                return aliceCredentials;
+            case HttpConstants.BOB:
+                return bobCredentials;
+            default:
+                return null;
+        }
     }
 
     public void logConfigSettings() {

--- a/src/main/java/org/solid/testharness/config/UserCredentials.java
+++ b/src/main/java/org/solid/testharness/config/UserCredentials.java
@@ -2,15 +2,29 @@ package org.solid.testharness.config;
 
 import io.quarkus.arc.config.ConfigProperties;
 
+import javax.validation.constraints.NotNull;
 import java.util.Optional;
 
 @ConfigProperties(prefix = "alice")
-public final class UserCredentials {
+public class UserCredentials {
+    @NotNull
     public Optional<String> refreshToken;
+    @NotNull
     public Optional<String> clientId;
+    @NotNull
     public Optional<String> clientSecret;
+    @NotNull
     public Optional<String> username;
+    @NotNull
     public Optional<String> password;
+
+    public UserCredentials() {
+        refreshToken = Optional.empty();
+        clientId = Optional.empty();
+        clientSecret = Optional.empty();
+        username = Optional.empty();
+        password = Optional.empty();
+    }
 
     public boolean isUsingUsernamePassword() {
         return username.isPresent() && password.isPresent();

--- a/src/main/java/org/solid/testharness/http/Client.java
+++ b/src/main/java/org/solid/testharness/http/Client.java
@@ -3,17 +3,12 @@ package org.solid.testharness.http;
 import org.apache.commons.text.RandomStringGenerator;
 import org.jose4j.jwk.RsaJsonWebKey;
 import org.jose4j.jwk.RsaJwkGenerator;
-import org.jose4j.jws.AlgorithmIdentifiers;
-import org.jose4j.jws.JsonWebSignature;
 import org.jose4j.jwt.JwtClaims;
 import org.jose4j.lang.JoseException;
-import org.jose4j.lang.UncheckedJoseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.X509TrustManager;
+import javax.validation.constraints.NotNull;
 import java.io.IOException;
 import java.net.CookieHandler;
 import java.net.CookieManager;
@@ -21,22 +16,23 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.security.KeyManagementException;
-import java.security.NoSuchAlgorithmException;
-import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
+import static java.util.Objects.requireNonNull;
 import static java.util.UUID.randomUUID;
 import static org.apache.commons.text.CharacterPredicates.DIGITS;
 import static org.apache.commons.text.CharacterPredicates.LETTERS;
-import static org.jose4j.jwx.HeaderParameterNames.TYPE;
 
-@SuppressWarnings("checkstyle:FinalClass") // Not final because it needs mocking for tests
+@SuppressWarnings({"checkstyle:FinalClass", "PMD.AvoidDuplicateLiterals"})
+// Class is not final because it needs mocking for tests
+// Duplicate string are null check error messages for same parameter
 public class Client {
     private static final Logger logger = LoggerFactory.getLogger(Client.class);
+
+    private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(5);
 
     private HttpClient httpClient;
     private String accessToken;
@@ -46,8 +42,8 @@ public class Client {
     private String user;
 
     public static class Builder {
-        private HttpClient.Builder clientBuilder;
-        private String user;
+        private final HttpClient.Builder clientBuilder;
+        private final String user;
         private RsaJsonWebKey clientKey;
 
         private static final RandomStringGenerator GENERATOR = new RandomStringGenerator.Builder()
@@ -60,7 +56,7 @@ public class Client {
             this.user = user;
             clientBuilder = HttpClient.newBuilder()
                     .version(HttpClient.Version.HTTP_1_1)
-                    .connectTimeout(Duration.ofSeconds(5));
+                    .connectTimeout(CONNECT_TIMEOUT);
         }
 
         public Builder withSessionSupport() {
@@ -70,39 +66,14 @@ public class Client {
         }
 
         public Builder withLocalhostSupport() {
-            // Allow self-signed certificates for testing
-            final TrustManager[] trustAllCerts = new TrustManager[]{
-                new X509TrustManager() {
-                    @Override
-                    public X509Certificate[] getAcceptedIssuers() {
-                        return new X509Certificate[0];
-                    }
-                    @Override
-                    public void checkClientTrusted(final X509Certificate[] certs, final String authType) { }
-                    @Override
-                    public void checkServerTrusted(final X509Certificate[] certs, final String authType) { }
-                }
-            };
-            SSLContext sslContext = null;
-            try {
-                sslContext = SSLContext.getInstance("SSL");
-                sslContext.init(null, trustAllCerts, new java.security.SecureRandom());
-            } catch (NoSuchAlgorithmException | KeyManagementException e) {
-                logger.error("Failed to setup sslContext", e);
-            }
             System.setProperty("jdk.internal.httpclient.disableHostnameVerification", Boolean.TRUE.toString());
-
-            clientBuilder.sslContext(sslContext);
+            clientBuilder.sslContext(LocalHostSupport.createSSLContext());
             return this;
         }
 
-        public Builder withDpopSupport() throws Exception {
+        public Builder withDpopSupport() throws JoseException {
             final String identifier = GENERATOR.generate(12);
-            try {
-                clientKey = RsaJwkGenerator.generateJwk(2048);
-            } catch (JoseException e) {
-                throw new Exception("Failed to generate client key", e);
-            }
+            clientKey = RsaJwkGenerator.generateJwk(2048);
             clientKey.setKeyId(identifier);
             clientKey.setUse("sig");
             clientKey.setAlgorithm("RS256");
@@ -136,20 +107,27 @@ public class Client {
         return user;
     }
 
-    public <T> HttpResponse<T> send(final HttpRequest request, final HttpResponse.BodyHandler<T> responseBodyHandler)
+    public <T> HttpResponse<T> send(@NotNull final HttpRequest request,
+                                    @NotNull final HttpResponse.BodyHandler<T> responseBodyHandler)
             throws IOException, InterruptedException {
+        requireNonNull(request, "request is required");
+        requireNonNull(responseBodyHandler, "responseBodyHandler is required");
         return httpClient.send(request, responseBodyHandler);
     }
 
-    public HttpResponse<String> getAsString(final URI url) throws IOException, InterruptedException {
+    public HttpResponse<String> getAsTurtle(@NotNull final URI url) throws IOException, InterruptedException {
+        requireNonNull(url, "url is required");
         final HttpRequest.Builder builder = HttpUtils.newRequestBuilder(url)
                 .header(HttpConstants.HEADER_ACCEPT, HttpConstants.MEDIA_TYPE_TEXT_TURTLE);
         final HttpRequest request = authorize(builder).build();
         return httpClient.send(request, HttpResponse.BodyHandlers.ofString());
     }
 
-    public HttpResponse<Void> put(final URI url, final String data, final String type)
+    public HttpResponse<Void> put(@NotNull final URI url, final String data, final String type)
             throws IOException, InterruptedException {
+        requireNonNull(url, "url is required");
+        requireNonNull(data, "data is required");
+        requireNonNull(type, "type is required");
         final HttpRequest.Builder builder = HttpUtils.newRequestBuilder(url)
                 .PUT(HttpRequest.BodyPublishers.ofString(data))
                 .header(HttpConstants.HEADER_CONTENT_TYPE, type);
@@ -160,7 +138,8 @@ public class Client {
         return response;
     }
 
-    public HttpResponse<Void> head(final URI url) throws IOException, InterruptedException {
+    public HttpResponse<Void> head(@NotNull final URI url) throws IOException, InterruptedException {
+        requireNonNull(url, "url is required");
         final HttpRequest.Builder builder = HttpUtils.newRequestBuilder(url)
                 .method(HttpConstants.METHOD_HEAD, HttpRequest.BodyPublishers.noBody());
         final HttpRequest request = authorize(builder).build();
@@ -170,37 +149,25 @@ public class Client {
         return response;
     }
 
-    public CompletableFuture<HttpResponse<Void>> deleteAsync(final URI url) {
+    public CompletableFuture<HttpResponse<Void>> deleteAsync(@NotNull final URI url) {
+        requireNonNull(url, "url is required");
         logger.debug("Deleting {}", url);
         final HttpRequest.Builder builder = HttpUtils.newRequestBuilder(url).DELETE();
-        final HttpRequest request;
-        try {
-            request = authorize(builder).build();
-        } catch (Exception e) {
-            logger.error("Failed to set up authorization", e);
-            return CompletableFuture.completedFuture(null);
-        }
+        final HttpRequest request = authorize(builder).build();
         return httpClient.sendAsync(request, HttpResponse.BodyHandlers.discarding());
     }
 
-    public HttpRequest.Builder signRequest(final HttpRequest.Builder builder) {
+    public HttpRequest.Builder signRequest(@NotNull final HttpRequest.Builder builder) {
+        requireNonNull(builder, "builder is required");
         if (!dpopSupported) return builder;
         final HttpRequest provisionalRequest = builder.copy().build();
         final String dpopToken = generateDpopToken(provisionalRequest.method(), provisionalRequest.uri().toString());
         return builder.header(HttpConstants.HEADER_DPOP, dpopToken);
     }
 
-    public  HttpRequest.Builder authorize(final HttpRequest.Builder builder) {
-        if (accessToken == null) return builder;
-        if (dpopSupported) {
-            builder.setHeader(HttpConstants.HEADER_AUTHORIZATION, HttpConstants.PREFIX_DPOP + accessToken);
-            return signRequest(builder);
-        } else {
-            return builder.setHeader(HttpConstants.HEADER_AUTHORIZATION, HttpConstants.PREFIX_BEARER + accessToken);
-        }
-    }
-
-    public Map<String, String> getAuthHeaders(final String method, final String uri) {
+    public Map<String, String> getAuthHeaders(@NotNull final String method, @NotNull final String uri) {
+        requireNonNull(method, "method is required");
+        requireNonNull(uri, "uri is required");
         final Map<String, String> headers = new HashMap<>();
         if (accessToken == null) return headers;
         if (dpopSupported) {
@@ -210,37 +177,36 @@ public class Client {
         } else {
             headers.put(HttpConstants.HEADER_AUTHORIZATION, HttpConstants.PREFIX_BEARER + accessToken);
         }
-        if (agent != null) {
-            headers.put(HttpConstants.USER_AGENT, agent);
-        }
+        headers.put(HttpConstants.USER_AGENT, agent);
         return headers;
     }
 
-    // TODO: Switch to elliptical curve as it is faster
-    public String generateDpopToken(final String htm, final String htu) {
-        if (clientKey == null) {
-            throw new RuntimeException("This instance does not have DPoP support added");
+    private HttpRequest.Builder authorize(@NotNull final HttpRequest.Builder builder) {
+        requireNonNull(builder, "builder is required");
+        if (accessToken == null) return builder;
+        if (dpopSupported) {
+            builder.setHeader(HttpConstants.HEADER_AUTHORIZATION, HttpConstants.PREFIX_DPOP + accessToken);
+            return signRequest(builder);
+        } else {
+            return builder.setHeader(HttpConstants.HEADER_AUTHORIZATION, HttpConstants.PREFIX_BEARER + accessToken);
         }
-        try {
-            final JsonWebSignature jws = new JsonWebSignature();
-//            jws.setAlgorithmHeaderValue(AlgorithmIdentifiers.ECDSA_USING_P256_CURVE_AND_SHA256);
-            jws.setAlgorithmHeaderValue(AlgorithmIdentifiers.RSA_USING_SHA256);
-            jws.setHeader(TYPE, "dpop+jwt");
-            jws.setJwkHeader(clientKey);
-            jws.setKey(clientKey.getPrivateKey());
+    }
 
-            final JwtClaims claims = new JwtClaims();
-            claims.setJwtId(randomUUID().toString());
-            claims.setStringClaim("htm", htm);
-            claims.setStringClaim("htu", htu);
-            claims.setIssuedAtToNow();
+    private String generateDpopToken(final String htm, final String htu) {
+        requireNonNull(clientKey, "This instance does not have DPoP support added");
+        final JwtClaims claims = new JwtClaims();
+        claims.setJwtId(randomUUID().toString());
+        claims.setStringClaim("htm", htm);
+        claims.setStringClaim("htu", htu);
+        claims.setIssuedAtToNow();
+        return JwsUtils.generateDpopToken(clientKey, claims);
+    }
 
-            jws.setPayload(claims.toJson());
-
-            return jws.getCompactSerialization();
-        } catch (final JoseException ex) {
-            throw new UncheckedJoseException("Unable to generate DPoP token", ex);
-        }
+    @Override
+    public String toString() {
+        return String.format("Client: user=%s, dPoP=%s, session=%s, local=%s",
+                user, dpopSupported, httpClient.cookieHandler().isPresent(),
+                System.getProperty("jdk.internal.httpclient.disableHostnameVerification", "false"));
     }
 
     private Client() { }

--- a/src/main/java/org/solid/testharness/http/HttpConstants.java
+++ b/src/main/java/org/solid/testharness/http/HttpConstants.java
@@ -12,6 +12,7 @@ public final class HttpConstants {
     public static final String HEADER_ACCEPT = "Accept";
     public static final String HEADER_LOCATION = "Location";
     public static final String HEADER_WAC_ALLOW = "wac-allow";
+    public static final String HEADER_LINK = "Link";
 
     public static final String PREFIX_DPOP = "DPoP ";
     public static final String PREFIX_BEARER = "Bearer ";
@@ -25,7 +26,7 @@ public final class HttpConstants {
     public static final String METHOD_HEAD = "HEAD";
     public static final int STATUS_OK = 200;
 
-    public static final String OPENID_CONFIGURATION = "/.well-known/openid-configuration";
+    public static final String OPENID_CONFIGURATION = ".well-known/openid-configuration";
     public static final String USER_AGENT = "User-Agent";
 
     public static final String GRANT_TYPE = "grant_type";

--- a/src/main/java/org/solid/testharness/http/JwsUtils.java
+++ b/src/main/java/org/solid/testharness/http/JwsUtils.java
@@ -1,0 +1,30 @@
+package org.solid.testharness.http;
+
+import org.jose4j.jwk.RsaJsonWebKey;
+import org.jose4j.jws.AlgorithmIdentifiers;
+import org.jose4j.jws.JsonWebSignature;
+import org.jose4j.jwt.JwtClaims;
+import org.jose4j.lang.JoseException;
+import org.jose4j.lang.UncheckedJoseException;
+
+import static org.jose4j.jwx.HeaderParameterNames.TYPE;
+
+public final class JwsUtils {
+    // TODO: Switch to elliptical curve as it is faster
+    public static String generateDpopToken(final RsaJsonWebKey clientKey, final JwtClaims claims) {
+        final JsonWebSignature jws = new JsonWebSignature();
+//            jws.setAlgorithmHeaderValue(AlgorithmIdentifiers.ECDSA_USING_P256_CURVE_AND_SHA256);
+        jws.setAlgorithmHeaderValue(AlgorithmIdentifiers.RSA_USING_SHA256);
+        jws.setHeader(TYPE, "dpop+jwt");
+        jws.setJwkHeader(clientKey);
+        jws.setKey(clientKey.getPrivateKey());
+        jws.setPayload(claims.toJson());
+        try {
+            return jws.getCompactSerialization();
+        } catch (final JoseException ex) {
+            throw new UncheckedJoseException("Unable to generate DPoP token", ex);
+        }
+    }
+
+    private JwsUtils() { }
+}

--- a/src/main/java/org/solid/testharness/http/LocalHostSupport.java
+++ b/src/main/java/org/solid/testharness/http/LocalHostSupport.java
@@ -1,0 +1,39 @@
+package org.solid.testharness.http;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.X509Certificate;
+
+public final class LocalHostSupport {
+    public static SSLContext createSSLContext() {
+        final TrustManager[] trustAllCerts = new TrustManager[]{
+            new X509TrustManager() {
+                @Override
+                public X509Certificate[] getAcceptedIssuers() {
+                    return new X509Certificate[0];
+                }
+
+                @Override
+                public void checkClientTrusted(final X509Certificate[] certs, final String authType) {
+                }
+
+                @Override
+                public void checkServerTrusted(final X509Certificate[] certs, final String authType) {
+                }
+            }
+        };
+        try {
+            // Allow self-signed certificates for testing
+            final SSLContext sslContext = SSLContext.getInstance("SSL");
+            sslContext.init(null, trustAllCerts, new java.security.SecureRandom());
+            return sslContext;
+        } catch (NoSuchAlgorithmException | KeyManagementException e) {
+            throw new RuntimeException("Failed to setup localhost ssl support", e);
+        }
+    }
+
+    private LocalHostSupport() { }
+}

--- a/src/main/java/org/solid/testharness/http/OidcConfiguration.java
+++ b/src/main/java/org/solid/testharness/http/OidcConfiguration.java
@@ -11,10 +11,11 @@ public class OidcConfiguration {
     private String registrationEndpoint;
 
     public String getIssuer() {
-        return issuer;
+        return issuer != null && !issuer.endsWith("/") ? issuer + "/" : issuer;
     }
 
-    public void set(final String issuer) {
+    @JsonSetter("issuer")
+    public void setIssuer(final String issuer) {
         this.issuer = issuer;
     }
 

--- a/src/main/java/org/solid/testharness/http/SolidClient.java
+++ b/src/main/java/org/solid/testharness/http/SolidClient.java
@@ -84,7 +84,7 @@ public class SolidClient {
     }
 
     public String getContainmentData(final URI url) throws Exception {
-        final HttpResponse<String> response = client.getAsString(url);
+        final HttpResponse<String> response = client.getAsTurtle(url);
         if (!HttpUtils.isSuccessful(response.statusCode())) {
             throw new Exception("Error response=" + response.statusCode() +
                     " trying to get container members for " + url);

--- a/src/main/java/org/solid/testharness/utils/SolidResource.java
+++ b/src/main/java/org/solid/testharness/utils/SolidResource.java
@@ -3,6 +3,7 @@ package org.solid.testharness.utils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.solid.testharness.http.HttpConstants;
 import org.solid.testharness.http.SolidClient;
 
 import java.net.URI;
@@ -38,7 +39,7 @@ public class SolidResource {
             final HttpHeaders headers;
             try {
                 headers = solidClient.createResource(resourceUri, body, type);
-                if (headers != null && headers.allValues("Link").size() != 0) {
+                if (headers != null && headers.allValues(HttpConstants.HEADER_LINK).size() != 0) {
                     final URI aclLink = solidClient.getAclLink(headers);
                     if (aclLink != null) {
                         logger.debug("ACL LINK {}", aclLink);

--- a/src/test/java/org/solid/testharness/config/ConfigTest.java
+++ b/src/test/java/org/solid/testharness/config/ConfigTest.java
@@ -3,6 +3,7 @@ package org.solid.testharness.config;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import org.junit.jupiter.api.Test;
+import org.solid.testharness.http.HttpConstants;
 import org.solid.testharness.utils.TestUtils;
 
 import javax.inject.Inject;
@@ -44,7 +45,7 @@ public class ConfigTest {
 
     @Test
     void getSolidIdentityProvider() {
-        assertEquals(URI.create("https://idp.example.org"), config.getSolidIdentityProvider());
+        assertEquals(URI.create("https://idp.example.org/"), config.getSolidIdentityProvider());
     }
 
     @Test
@@ -70,6 +71,21 @@ public class ConfigTest {
     @Test
     void getBobWebId() {
         assertEquals("https://bob.target.example.org/profile/card#me", config.getBobWebId());
+    }
+
+    @Test
+    void getCredentialsAlice() {
+        assertNotNull(config.getCredentials(HttpConstants.ALICE));
+    }
+
+    @Test
+    void getCredentialsBob() {
+        assertNotNull(config.getCredentials(HttpConstants.BOB));
+    }
+
+    @Test
+    void getCredentialsCharlie() {
+        assertNull(config.getCredentials("charlie"));
     }
 
     @Test

--- a/src/test/java/org/solid/testharness/config/ConfigTestNormalProfile.java
+++ b/src/test/java/org/solid/testharness/config/ConfigTestNormalProfile.java
@@ -2,8 +2,30 @@ package org.solid.testharness.config;
 
 import io.quarkus.test.junit.QuarkusTestProfile;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
 public class ConfigTestNormalProfile implements QuarkusTestProfile {
+    @Override
     public String getConfigProfile() {
         return "test";
+    }
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        return Map.of(
+                "SOLID_IDENTITY_PROVIDER", "https://idp.example.org",
+                "LOGIN_ENDPOINT", "https://example.org/login/password",
+                "SERVER_ROOT", "https://target.example.org",
+                "TEST_CONTAINER", "test",
+                "ALICE_WEBID", "https://alice.target.example.org/profile/card#me",
+                "BOB_WEBID", "https://bob.target.example.org/profile/card#me"
+        );
+    }
+
+    @Override
+    public List<TestResourceEntry> testResources() {
+        return Collections.emptyList();
     }
 }

--- a/src/test/java/org/solid/testharness/config/TestSubjectTest.java
+++ b/src/test/java/org/solid/testharness/config/TestSubjectTest.java
@@ -1,6 +1,7 @@
 package org.solid.testharness.config;
 
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
 import io.quarkus.test.junit.mockito.InjectMock;
 import org.junit.jupiter.api.Test;
 import org.solid.testharness.http.*;
@@ -21,6 +22,7 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 @QuarkusTest
+@TestProfile(ConfigTestNormalProfile.class)
 public class TestSubjectTest {
     @Inject
     Config config;
@@ -49,7 +51,7 @@ public class TestSubjectTest {
         config.setTestSubject(iri("https://github.com/solid/conformance-test-harness/example"));
         final Client mockClient = mock(Client.class);
         final HttpResponse<Void> mockResponse = mock(HttpResponse.class);
-        final Map<String, List<String>> headerMap = Map.of("Link",
+        final Map<String, List<String>> headerMap = Map.of(HttpConstants.HEADER_LINK,
                 List.of("<https://target.example.org/.acl>; rel=\"acl\""));
         final HttpHeaders mockHeaders = HttpHeaders.of(headerMap, (k, v) -> true);
         final HttpResponse<Void> mockResponseOk = mockVoidResponse(200);
@@ -79,7 +81,7 @@ public class TestSubjectTest {
         config.setTestSubject(iri("https://github.com/solid/conformance-test-harness/example"));
         final Client mockClient = mock(Client.class);
         final HttpResponse<Void> mockResponse = mock(HttpResponse.class);
-        final Map<String, List<String>> headerMap = Map.of("Link",
+        final Map<String, List<String>> headerMap = Map.of(HttpConstants.HEADER_LINK,
                 List.of("<http://localhost/.acl>; rel=\"acl\""));
         final HttpHeaders mockHeaders = HttpHeaders.of(headerMap, (k, v) -> true);
         final HttpResponse<Void> mockResponseOk = mockVoidResponse(200);
@@ -99,7 +101,7 @@ public class TestSubjectTest {
         config.setTestSubject(iri("https://github.com/solid/conformance-test-harness/example"));
         final Client mockClient = mock(Client.class);
         final HttpResponse<Void> mockResponse = mock(HttpResponse.class);
-        final Map<String, List<String>> headerMap = Map.of("Link",
+        final Map<String, List<String>> headerMap = Map.of(HttpConstants.HEADER_LINK,
                 List.of("<http://localhost/.acl>; rel=\"notacl\""));
         final HttpHeaders mockHeaders = HttpHeaders.of(headerMap, (k, v) -> true);
 
@@ -119,7 +121,7 @@ public class TestSubjectTest {
         config.setTestSubject(iri("https://github.com/solid/conformance-test-harness/example"));
         final Client mockClient = mock(Client.class);
         final HttpResponse<Void> mockResponse = mock(HttpResponse.class);
-        final Map<String, List<String>> headerMap = Map.of("Link",
+        final Map<String, List<String>> headerMap = Map.of(HttpConstants.HEADER_LINK,
                 List.of("<http://localhost/.acl>; rel=\"acl\""));
         final HttpHeaders mockHeaders = HttpHeaders.of(headerMap, (k, v) -> true);
         final HttpResponse<Void> mockResponseOk = mockVoidResponse(500);

--- a/src/test/java/org/solid/testharness/config/UserCredentialsTest.java
+++ b/src/test/java/org/solid/testharness/config/UserCredentialsTest.java
@@ -12,9 +12,6 @@ public class UserCredentialsTest {
         final UserCredentials userCredentials = new UserCredentials();
         userCredentials.username = Optional.of("USERNAME");
         userCredentials.password = Optional.of("PASSWORD");
-        userCredentials.refreshToken = Optional.empty();
-        userCredentials.clientId = Optional.empty();
-        userCredentials.clientSecret = Optional.empty();
 
         assertFalse(userCredentials.isUsingRefreshToken());
         assertTrue(userCredentials.isUsingUsernamePassword());
@@ -35,8 +32,6 @@ public class UserCredentialsTest {
     @Test
     public void refreshCredentials() {
         final UserCredentials userCredentials = new UserCredentials();
-        userCredentials.username = Optional.empty();
-        userCredentials.password = Optional.empty();
         userCredentials.refreshToken = Optional.of("TOKEN");
         userCredentials.clientId = Optional.of("CLIENT_ID");
         userCredentials.clientSecret = Optional.of("CLIENT_SECRET");
@@ -66,11 +61,6 @@ public class UserCredentialsTest {
     @Test
     public void emptyCredentials() {
         final UserCredentials userCredentials = new UserCredentials();
-        userCredentials.username = Optional.empty();
-        userCredentials.password = Optional.empty();
-        userCredentials.refreshToken = Optional.empty();
-        userCredentials.clientId = Optional.empty();
-        userCredentials.clientSecret = Optional.empty();
         assertFalse(userCredentials.isUsingRefreshToken());
         assertFalse(userCredentials.isUsingUsernamePassword());
         assertEquals("UserCredentials: username=null, password=null, " +

--- a/src/test/java/org/solid/testharness/http/AuthManagerTest.java
+++ b/src/test/java/org/solid/testharness/http/AuthManagerTest.java
@@ -1,0 +1,287 @@
+package org.solid.testharness.http;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.mockito.InjectMock;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.solid.testharness.config.Config;
+import org.solid.testharness.config.TargetServer;
+import org.solid.testharness.config.UserCredentials;
+import org.solid.testharness.utils.TestData;
+import org.solid.testharness.utils.TestHarnessInitializationException;
+
+import javax.inject.Inject;
+import javax.validation.ConstraintViolationException;
+import java.net.URI;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@QuarkusTest
+@QuarkusTestResource(AuthenticationResource.class)
+class AuthManagerTest {
+    private URI baseUri;
+
+    @Inject
+    AuthManager authManager;
+
+    @InjectMock
+    ClientRegistry clientRegistry;
+
+    @InjectMock
+    Config config;
+
+    @BeforeEach
+    void setup() {
+        System.clearProperty("jdk.internal.httpclient.disableHostnameVerification");
+    }
+
+    @Test
+    void authenticateNullUser() {
+        final TargetServer targetServer = mock(TargetServer.class);
+        assertThrows(ConstraintViolationException.class, () -> authManager.authenticate(null, targetServer));
+    }
+
+    @Test
+    void authenticateNullTarget() {
+        assertThrows(ConstraintViolationException.class, () -> authManager.authenticate("alice", null));
+    }
+
+    @Test
+    void authenticateNonAuthenticatingTarget() throws Exception {
+        when(clientRegistry.getClient(ClientRegistry.DEFAULT)).thenReturn(new Client.Builder().build());
+        final TargetServer targetServer = mock(TargetServer.class);
+        when(targetServer.getFeatures()).thenReturn(Collections.emptyMap());
+        final SolidClient solidClient = authManager.authenticate("ignored", targetServer);
+        assertTrue(solidClient.getClient().getUser().isEmpty());
+    }
+
+    @Test
+    void authenticateAlreadyExists() throws Exception {
+        final TargetServer targetServer = getMockTargetServer(true);
+        when(clientRegistry.hasClient("existing")).thenReturn(true);
+        when(clientRegistry.getClient("existing")).thenReturn(new Client.Builder("existing").build());
+        final SolidClient solidClient = authManager.authenticate("existing", targetServer);
+        assertEquals("existing", solidClient.getClient().getUser());
+        verify(config, never()).getCredentials("existing");
+    }
+
+    @Test
+    void authenticateNoDpopNoOidc() {
+        final TargetServer targetServer = getMockTargetServer(true);
+        when(config.getSolidIdentityProvider()).thenReturn(baseUri.resolve("/404/"));
+        when(config.getServerRoot()).thenReturn(URI.create(TestData.SAMPLE_BASE));
+
+        assertThrows(TestHarnessInitializationException.class,
+                () -> authManager.authenticate("test1", targetServer));
+
+        final ArgumentCaptor<Client> argumentCaptor = ArgumentCaptor.forClass(Client.class);
+        verify(clientRegistry).register(eq("test1"), argumentCaptor.capture());
+        assertEquals("Client: user=test1, dPoP=false, session=false, local=false",
+                argumentCaptor.getValue().toString());
+    }
+
+    @Test
+    void authenticateDpopLocalhostNoOidc() {
+        final TargetServer targetServer = getMockTargetServer(false);
+        when(config.getSolidIdentityProvider()).thenReturn(baseUri.resolve("/404/"));
+        when(config.getServerRoot()).thenReturn(URI.create("https://localhost"));
+        assertThrows(TestHarnessInitializationException.class,
+                () -> authManager.authenticate("test2", targetServer));
+
+        final ArgumentCaptor<Client> argumentCaptor = ArgumentCaptor.forClass(Client.class);
+        verify(clientRegistry).register(eq("test2"), argumentCaptor.capture());
+        assertEquals("Client: user=test2, dPoP=true, session=false, local=true",
+                argumentCaptor.getValue().toString());
+    }
+
+    @Test
+    void authenticateDpopLocalhostBadIssuer() {
+        final TargetServer targetServer = getMockTargetServer(false);
+        when(config.getSolidIdentityProvider()).thenReturn(baseUri.resolve("/badissuer/"));
+        when(config.getServerRoot()).thenReturn(URI.create("http://localhost"));
+
+        assertThrows(TestHarnessInitializationException.class,
+                () -> authManager.authenticate("test3", targetServer));
+
+        final ArgumentCaptor<Client> argumentCaptor = ArgumentCaptor.forClass(Client.class);
+        verify(clientRegistry).register(eq("test3"), argumentCaptor.capture());
+        assertEquals("Client: user=test3, dPoP=true, session=false, local=true",
+                argumentCaptor.getValue().toString());
+    }
+
+    @Test
+    void authenticateNullCredentials() {
+        final TargetServer targetServer = getMockTargetServer(false);
+        when(config.getSolidIdentityProvider()).thenReturn(baseUri);
+        when(config.getServerRoot()).thenReturn(URI.create(TestData.SAMPLE_BASE));
+        when(config.getCredentials("test4")).thenReturn(null);
+
+        assertThrows(TestHarnessInitializationException.class,
+                () -> authManager.authenticate("test4", targetServer));
+    }
+
+    @Test
+    void authenticateMissingCredentials() {
+        final TargetServer targetServer = getMockTargetServer(false);
+        when(config.getSolidIdentityProvider()).thenReturn(baseUri);
+        when(config.getServerRoot()).thenReturn(URI.create(TestData.SAMPLE_BASE));
+        when(config.getCredentials("test5")).thenReturn(new UserCredentials());
+
+        assertThrows(TestHarnessInitializationException.class,
+                () -> authManager.authenticate("test5", targetServer));
+    }
+
+    @Test
+    void authenticateRefreshCredentialsFails() {
+        final TargetServer targetServer = getMockTargetServer(false);
+        when(config.getSolidIdentityProvider()).thenReturn(baseUri);
+        when(config.getServerRoot()).thenReturn(URI.create(TestData.SAMPLE_BASE));
+        final UserCredentials credentials = new UserCredentials();
+        credentials.refreshToken = Optional.of("REFRESH");
+        credentials.clientId = Optional.of("CLIENTID");
+        credentials.clientSecret = Optional.of("BADSECRET");
+        when(config.getCredentials("test7")).thenReturn(credentials);
+
+        final TestHarnessInitializationException exception = assertThrows(TestHarnessInitializationException.class,
+                () -> authManager.authenticate("test7", targetServer));
+        assertEquals("Token exchange failed for grant type: " + HttpConstants.REFRESH_TOKEN,
+                exception.getMessage());
+    }
+
+    @Test
+    void authenticateRefreshCredentials() throws Exception {
+        final TargetServer targetServer = getMockTargetServer(false);
+        when(config.getSolidIdentityProvider()).thenReturn(baseUri);
+        when(config.getServerRoot()).thenReturn(URI.create(TestData.SAMPLE_BASE));
+        final UserCredentials credentials = new UserCredentials();
+        credentials.refreshToken = Optional.of("REFRESH");
+        credentials.clientId = Optional.of("CLIENTID");
+        credentials.clientSecret = Optional.of("CLIENTSECRET");
+        when(config.getCredentials("test6")).thenReturn(credentials);
+
+        final SolidClient solidClient = authManager.authenticate("test6", targetServer);
+        assertEquals("ACCESS_TOKEN", solidClient.getClient().getAccessToken());
+    }
+
+    @Test
+    void authenticateLoginSessionFails() {
+        final TargetServer targetServer = getMockTargetServer(false);
+        when(clientRegistry.getClient(ClientRegistry.SESSION_BASED)).thenReturn(new Client.Builder().build());
+        setupLogin("test8", "BADPASSWORD");
+
+        final TestHarnessInitializationException exception = assertThrows(TestHarnessInitializationException.class,
+                () -> authManager.authenticate("test8", targetServer));
+        assertEquals("Login failed with status code 403", exception.getMessage());
+    }
+
+    @Test
+    void authenticateLoginRegisterFails() {
+        final TargetServer targetServer = getMockTargetServer(false);
+        when(clientRegistry.getClient(ClientRegistry.SESSION_BASED)).thenReturn(new Client.Builder().build());
+        when(targetServer.getOrigin()).thenReturn("BADORIGIN");
+        setupLogin("test9", "PASSWORD");
+
+        final TestHarnessInitializationException exception = assertThrows(TestHarnessInitializationException.class,
+                () -> authManager.authenticate("test9", targetServer));
+        assertEquals("Registration failed with status code 400", exception.getMessage());
+    }
+
+    @Test
+    void authenticateLoginAuthorizationFails() {
+        final TargetServer targetServer = getMockTargetServer(false);
+        when(clientRegistry.getClient(ClientRegistry.SESSION_BASED)).thenReturn(new Client.Builder().build());
+        when(targetServer.getOrigin()).thenReturn("AUTHFAIL");
+        setupLogin("test10", "PASSWORD");
+
+        final TestHarnessInitializationException exception = assertThrows(TestHarnessInitializationException.class,
+                () -> authManager.authenticate("test10", targetServer));
+        assertEquals("Authorization failed with status code 400", exception.getMessage());
+    }
+
+    @Test
+    void authenticateLoginAuthorizationFailsWithoutRedirect() {
+        final TargetServer targetServer = getMockTargetServer(false);
+        when(clientRegistry.getClient(ClientRegistry.SESSION_BASED)).thenReturn(new Client.Builder().build());
+        when(targetServer.getOrigin()).thenReturn("https://origin/noredirect");
+        setupLogin("test11", "PASSWORD");
+
+        final TestHarnessInitializationException exception = assertThrows(TestHarnessInitializationException.class,
+                () -> authManager.authenticate("test11", targetServer));
+        assertEquals("Failed to follow authentication redirects", exception.getMessage());
+    }
+
+    @Test
+    void authenticateLoginNoRedirectFailsNoCode() {
+        final TargetServer targetServer = getMockTargetServer(false);
+        when(clientRegistry.getClient(ClientRegistry.SESSION_BASED)).thenReturn(new Client.Builder().build());
+        when(targetServer.getOrigin()).thenReturn("https://origin/immediate");
+        setupLogin("test12", "PASSWORD");
+
+        final TestHarnessInitializationException exception = assertThrows(TestHarnessInitializationException.class,
+                () -> authManager.authenticate("test12", targetServer));
+        assertEquals("Failed to get authorization code", exception.getMessage());
+    }
+
+    @Test
+    void authenticateLoginOneRedirectFailsNoCode() {
+        final TargetServer targetServer = getMockTargetServer(false);
+        when(clientRegistry.getClient(ClientRegistry.SESSION_BASED)).thenReturn(new Client.Builder().build());
+        when(targetServer.getOrigin()).thenReturn("https://origin/redirect");
+        setupLogin("test13", "PASSWORD");
+
+        final TestHarnessInitializationException exception = assertThrows(TestHarnessInitializationException.class,
+                () -> authManager.authenticate("test13", targetServer));
+        assertEquals("Failed to get authorization code", exception.getMessage());
+    }
+
+    @Test
+    void authenticateLoginTokenFails() throws Exception {
+        final TargetServer targetServer = getMockTargetServer(false);
+        when(clientRegistry.getClient(ClientRegistry.SESSION_BASED)).thenReturn(new Client.Builder().build());
+        when(targetServer.getOrigin()).thenReturn("https://origin/badcode");
+        setupLogin("test14", "PASSWORD");
+
+        final TestHarnessInitializationException exception = assertThrows(TestHarnessInitializationException.class,
+                () -> authManager.authenticate("test14", targetServer));
+        assertEquals("Token exchange failed for grant type: " + HttpConstants.AUTHORIZATION_CODE_TYPE,
+                exception.getMessage());
+    }
+
+    @Test
+    void authenticateLoginTokenSucceeds() throws Exception {
+        final TargetServer targetServer = getMockTargetServer(false);
+        when(clientRegistry.getClient(ClientRegistry.SESSION_BASED)).thenReturn(new Client.Builder().build());
+        when(targetServer.getOrigin()).thenReturn("https://origin/goodcode");
+        setupLogin("test15", "PASSWORD");
+
+        final SolidClient solidClient = authManager.authenticate("test15", targetServer);
+        assertEquals("ACCESS_TOKEN", solidClient.getClient().getAccessToken());
+    }
+
+    public void setBaseUri(final URI baseUri) {
+        this.baseUri = baseUri;
+    }
+
+    private TargetServer getMockTargetServer(final boolean disableDpop) {
+        final TargetServer targetServer = mock(TargetServer.class);
+        when(targetServer.getFeatures()).thenReturn(Map.of("authentication", true));
+        when(targetServer.isDisableDPoP()).thenReturn(disableDpop);
+        return targetServer;
+    }
+
+    private void setupLogin(final String testId, final String password) {
+        when(config.getSolidIdentityProvider()).thenReturn(baseUri);
+        when(config.getLoginEndpoint()).thenReturn(baseUri.resolve("/login/password"));
+        when(config.getServerRoot()).thenReturn(URI.create(TestData.SAMPLE_BASE));
+        final UserCredentials credentials = new UserCredentials();
+        credentials.username = Optional.of("USERNAME");
+        credentials.password = Optional.of(password);
+        when(config.getCredentials(testId)).thenReturn(credentials);
+    }
+}

--- a/src/test/java/org/solid/testharness/http/AuthenticationResource.java
+++ b/src/test/java/org/solid/testharness/http/AuthenticationResource.java
@@ -1,0 +1,203 @@
+package org.solid.testharness.http;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.http.Request;
+import com.github.tomakehurst.wiremock.http.Response;
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.containing;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+
+public class AuthenticationResource implements QuarkusTestResourceLifecycleManager {
+    private static final Logger logger = LoggerFactory.getLogger(AuthenticationResource.class);
+
+    private WireMockServer wireMockServer;
+
+    private static final String CLIENT_REGISTRATION = "{\"client_id\": \"CLIENTID\"," +
+            "\"client_secret\": \"CLIENTSECRET\"}";
+
+    private static final String ACCESS_TOKEN = "{\"access_token\": \"ACCESS_TOKEN\"}";
+
+    private static final String GOOD_BASIC_AUTH = HttpConstants.PREFIX_BASIC +
+            Base64.getEncoder().encodeToString("CLIENTID:CLIENTSECRET".getBytes());
+    private static final String BAD_BASIC_AUTH = HttpConstants.PREFIX_BASIC +
+            Base64.getEncoder().encodeToString("CLIENTID:BADSECRET".getBytes());
+
+    @Override
+    public Map<String, String> start() {
+        wireMockServer = new WireMockServer(WireMockConfiguration.options()
+                .dynamicPort());
+// logging the requests helps when debugging tests
+//        wireMockServer.addMockServiceRequestListener(AuthenticationResource::requestReceived);
+
+        wireMockServer.start();
+
+        wireMockServer.stubFor(WireMock.get(WireMock.urlEqualTo("/404/" + HttpConstants.OPENID_CONFIGURATION))
+                .willReturn(WireMock.aResponse().withStatus(404)));
+
+        wireMockServer.stubFor(WireMock.get(WireMock.urlEqualTo("/badissuer/" + HttpConstants.OPENID_CONFIGURATION))
+                .willReturn(WireMock.aResponse()
+                        .withHeader(HttpConstants.HEADER_CONTENT_TYPE, HttpConstants.MEDIA_TYPE_APPLICATION_JSON)
+                        .withBody(getDiscoveryDocument("https://badissuer"))));
+
+        wireMockServer.stubFor(WireMock.get(WireMock.urlEqualTo("/" + HttpConstants.OPENID_CONFIGURATION))
+                .willReturn(WireMock.aResponse()
+                        .withHeader(HttpConstants.HEADER_CONTENT_TYPE, HttpConstants.MEDIA_TYPE_APPLICATION_JSON)
+                        .withBody(getDiscoveryDocument(wireMockServer.baseUrl()))));
+
+        // refresh token fails with bad authentication
+        wireMockServer.stubFor(WireMock.post(WireMock.urlEqualTo("/token"))
+                .withHeader(HttpConstants.HEADER_AUTHORIZATION, equalTo(BAD_BASIC_AUTH))
+                .withRequestBody(containing(HttpConstants.REFRESH_TOKEN))
+                .willReturn(WireMock.aResponse()
+                        .withStatus(403)));
+
+        // refresh token succeeds with good authentication
+        wireMockServer.stubFor(WireMock.post(WireMock.urlEqualTo("/token"))
+                .withHeader(HttpConstants.HEADER_AUTHORIZATION, equalTo(GOOD_BASIC_AUTH))
+                .withRequestBody(containing(HttpConstants.REFRESH_TOKEN))
+                .willReturn(WireMock.aResponse()
+                        .withHeader(HttpConstants.HEADER_CONTENT_TYPE, HttpConstants.MEDIA_TYPE_APPLICATION_JSON)
+                        .withBody(ACCESS_TOKEN)));
+
+        // session login fails with bad password
+        wireMockServer.stubFor(WireMock.post(WireMock.urlEqualTo("/login/password"))
+                .withRequestBody(containing(HttpConstants.PASSWORD + "=BADPASSWORD"))
+                .willReturn(WireMock.aResponse().withStatus(403)));
+
+        // session login succeeds with good password
+        wireMockServer.stubFor(WireMock.post(WireMock.urlEqualTo("/login/password"))
+                .withRequestBody(containing(HttpConstants.PASSWORD + "=PASSWORD"))
+                .willReturn(WireMock.aResponse()));
+
+        // registration fails with bad redirect uri
+        wireMockServer.stubFor(WireMock.post(WireMock.urlEqualTo("/register"))
+                .withRequestBody(containing("\"redirect_uris\":[\"BADORIGIN\"]"))
+                .willReturn(WireMock.aResponse().withStatus(400)));
+
+        // register succeeds but authorization will fail
+        wireMockServer.stubFor(WireMock.post(WireMock.urlEqualTo("/register"))
+                .withRequestBody(containing("\"redirect_uris\":[\"AUTHFAIL\"]"))
+                .willReturn(WireMock.aResponse()
+                        .withHeader(HttpConstants.HEADER_CONTENT_TYPE, HttpConstants.MEDIA_TYPE_APPLICATION_JSON)
+                        .withBody("{\"client_id\": \"BADCLIENTID\"}")));
+
+        // authorization will fail due to bad client id
+        wireMockServer.stubFor(WireMock.get(WireMock.urlPathEqualTo("/authorization"))
+                .withQueryParam(HttpConstants.REDIRECT_URI, equalTo("AUTHFAIL"))
+                .withQueryParam(HttpConstants.CLIENT_ID, equalTo("BADCLIENTID"))
+                .willReturn(WireMock.aResponse().withStatus(400)));
+
+        // register succeeds
+        wireMockServer.stubFor(WireMock.post(WireMock.urlEqualTo("/register"))
+                .withRequestBody(containing("\"redirect_uris\":[\"https://origin"))
+                .willReturn(WireMock.aResponse()
+                        .withHeader(HttpConstants.HEADER_CONTENT_TYPE, HttpConstants.MEDIA_TYPE_APPLICATION_JSON)
+                        .withBody(CLIENT_REGISTRATION)));
+
+        // authorization will fail due to no redirect url
+        wireMockServer.stubFor(WireMock.get(WireMock.urlPathEqualTo("/authorization"))
+                .withQueryParam(HttpConstants.REDIRECT_URI, containing("noredirect"))
+                .withQueryParam(HttpConstants.CLIENT_ID, equalTo("CLIENTID"))
+                .willReturn(WireMock.aResponse()
+                        .withStatus(302)));
+
+        // authorization will get immediate response but no authorization code
+        wireMockServer.stubFor(WireMock.get(WireMock.urlPathEqualTo("/authorization"))
+                .withQueryParam(HttpConstants.REDIRECT_URI, equalTo("https://origin/immediate"))
+                .withQueryParam(HttpConstants.CLIENT_ID, equalTo("CLIENTID"))
+                .willReturn(WireMock.aResponse()
+                        .withHeader(HttpConstants.HEADER_LOCATION, "https://origin/immediate?")
+                        .withStatus(302)));
+
+        // authorization will get a redirect
+        wireMockServer.stubFor(WireMock.get(WireMock.urlPathEqualTo("/authorization"))
+                .withQueryParam(HttpConstants.REDIRECT_URI, equalTo("https://origin/redirect"))
+                .withQueryParam(HttpConstants.CLIENT_ID, equalTo("CLIENTID"))
+                .willReturn(WireMock.aResponse()
+                        .withHeader(HttpConstants.HEADER_LOCATION, "/authorization?redirect=1")
+                        .withStatus(302)));
+
+        // authorization after redirect will get no authorization code
+        wireMockServer.stubFor(WireMock.get(WireMock.urlPathEqualTo("/authorization"))
+                .withQueryParam("redirect", equalTo("1"))
+                .willReturn(WireMock.aResponse()
+                        .withHeader(HttpConstants.HEADER_LOCATION, "https://origin/redirect?")
+                        .withStatus(302)));
+
+        // authorization will get immediate response with a bad authorization code
+        wireMockServer.stubFor(WireMock.get(WireMock.urlPathEqualTo("/authorization"))
+                .withQueryParam(HttpConstants.REDIRECT_URI, equalTo("https://origin/badcode"))
+                .withQueryParam(HttpConstants.CLIENT_ID, equalTo("CLIENTID"))
+                .willReturn(WireMock.aResponse()
+                        .withHeader(HttpConstants.HEADER_LOCATION, "https://origin/badcode?code=badcode")
+                        .withStatus(302)));
+
+        // token request fails due to bad authorization code
+        wireMockServer.stubFor(WireMock.post(WireMock.urlEqualTo("/token"))
+                .withHeader(HttpConstants.HEADER_AUTHORIZATION, equalTo(GOOD_BASIC_AUTH))
+                .withRequestBody(containing(HttpConstants.AUTHORIZATION_CODE_TYPE))
+                .withRequestBody(containing(HttpConstants.CODE + "=badcode"))
+                .willReturn(WireMock.aResponse().withStatus(403)));
+
+        // authorization will get immediate response with a good authorization code
+        wireMockServer.stubFor(WireMock.get(WireMock.urlPathEqualTo("/authorization"))
+                .withQueryParam(HttpConstants.REDIRECT_URI, equalTo("https://origin/goodcode"))
+                .withQueryParam(HttpConstants.CLIENT_ID, equalTo("CLIENTID"))
+                .willReturn(WireMock.aResponse()
+                        .withHeader(HttpConstants.HEADER_LOCATION, "https://origin/goodcode?code=authorized")
+                        .withStatus(302)));
+
+        // token request succeeds
+        wireMockServer.stubFor(WireMock.post(WireMock.urlEqualTo("/token"))
+                .withHeader(HttpConstants.HEADER_AUTHORIZATION, equalTo(GOOD_BASIC_AUTH))
+                .withRequestBody(containing(HttpConstants.AUTHORIZATION_CODE_TYPE))
+                .withRequestBody(containing(HttpConstants.CODE + "=authorized"))
+                .willReturn(WireMock.aResponse()
+                        .withHeader(HttpConstants.HEADER_CONTENT_TYPE, HttpConstants.MEDIA_TYPE_APPLICATION_JSON)
+                        .withBody(ACCESS_TOKEN)));
+
+        return Collections.emptyMap();
+    }
+
+    protected static void requestReceived(final Request inRequest, final Response inResponse) {
+        logger.info("WireMock request at URL: {}", inRequest.getAbsoluteUrl());
+        logger.info("WireMock request headers: \n{}", inRequest.getHeaders());
+        logger.info("WireMock request body: \n{}", inRequest.getBodyAsString());
+        logger.info("WireMock response body: \n{}", inResponse.getBodyAsString());
+        logger.info("WireMock response headers: \n{}", inResponse.getHeaders());
+    }
+
+    @Override
+    public void stop() {
+        if (null != wireMockServer) {
+            wireMockServer.stop();
+        }
+    }
+
+    @Override
+    public void inject(final Object testInstance) {
+        // pass the wiremock base uri back into the test so that it can be modified for different scenarios
+        if (testInstance instanceof AuthManagerTest) {
+            ((AuthManagerTest) testInstance).setBaseUri(URI.create(wireMockServer.baseUrl() + "/"));
+        }
+    }
+
+    String getDiscoveryDocument(final String baseUrl) {
+        return "{" +
+                "\"issuer\": \"" + baseUrl + "\"," +
+                "\"authorization_endpoint\": \"" + baseUrl + "/authorization\"," +
+                "\"token_endpoint\": \"" + baseUrl + "/token\"," +
+                "\"registration_endpoint\": \"" + baseUrl + "/register\"" +
+                "}";
+    }
+}

--- a/src/test/java/org/solid/testharness/http/ClientRegistryTest.java
+++ b/src/test/java/org/solid/testharness/http/ClientRegistryTest.java
@@ -1,0 +1,64 @@
+package org.solid.testharness.http;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+class ClientRegistryTest {
+    @Inject
+    ClientRegistry clientRegistry;
+
+    @Test
+    void register() {
+        clientRegistry.register("registerTest", new Client.Builder("registerTest").build());
+        assertEquals("registerTest", clientRegistry.getClient("registerTest").getUser());
+    }
+
+    @Test
+    void unregister() {
+        clientRegistry.register("unregisterTest", new Client.Builder("unregisterTest").build());
+        assertEquals("registerTest", clientRegistry.getClient("registerTest").getUser());
+        clientRegistry.unregister("unregisterTest");
+        assertNull(clientRegistry.getClient("unregisterTest"));
+    }
+
+    @Test
+    void hasClient() {
+        assertTrue(clientRegistry.hasClient(ClientRegistry.DEFAULT));
+    }
+
+    @Test
+    void hasClientFalse() {
+        assertFalse(clientRegistry.hasClient("unknown"));
+    }
+
+    @Test
+    void getClient() {
+        clientRegistry.register("newClient", new Client.Builder("newClient").build());
+        assertEquals("newClient", clientRegistry.getClient("newClient").getUser());
+    }
+
+    @Test
+    void getClientSessionBased() {
+        assertTrue(clientRegistry.getClient(ClientRegistry.SESSION_BASED).getHttpClient().cookieHandler().isPresent());
+    }
+
+    @Test
+    void getClientDefault() {
+        assertFalse(clientRegistry.getClient(ClientRegistry.DEFAULT).getHttpClient().cookieHandler().isPresent());
+    }
+
+    @Test
+    void getClientMissing() {
+        assertNull(clientRegistry.getClient("unknown"));
+    }
+
+    @Test
+    void getClientNoLabel() {
+        assertEquals(clientRegistry.getClient(ClientRegistry.DEFAULT), clientRegistry.getClient(null));
+    }
+}

--- a/src/test/java/org/solid/testharness/http/ClientResource.java
+++ b/src/test/java/org/solid/testharness/http/ClientResource.java
@@ -1,0 +1,86 @@
+package org.solid.testharness.http;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.http.Fault;
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.absent;
+import static com.github.tomakehurst.wiremock.client.WireMock.containing;
+import static com.github.tomakehurst.wiremock.client.WireMock.matching;
+
+public class ClientResource implements QuarkusTestResourceLifecycleManager {
+    private WireMockServer wireMockServer;
+
+    @Override
+    public Map<String, String> start() {
+        wireMockServer = new WireMockServer(WireMockConfiguration.options()
+                .dynamicPort());
+        wireMockServer.start();
+
+        wireMockServer.stubFor(WireMock.get(WireMock.urlEqualTo("/get/404"))
+                .willReturn(WireMock.aResponse().withStatus(404)));
+
+        wireMockServer.stubFor(WireMock.get(WireMock.urlEqualTo("/get/fault"))
+                .willReturn(WireMock.aResponse().withFault(Fault.MALFORMED_RESPONSE_CHUNK)));
+
+        wireMockServer.stubFor(WireMock.get(WireMock.urlEqualTo("/get/turtle"))
+                .withHeader(HttpConstants.HEADER_AUTHORIZATION, absent())
+                .willReturn(WireMock.aResponse()
+                        .withHeader(HttpConstants.HEADER_CONTENT_TYPE, HttpConstants.MEDIA_TYPE_TEXT_TURTLE)
+                        .withBody("TURTLE-NOAUTH")));
+
+        wireMockServer.stubFor(WireMock.get(WireMock.urlEqualTo("/get/turtle"))
+                .withHeader(HttpConstants.HEADER_AUTHORIZATION, containing(HttpConstants.PREFIX_DPOP))
+                .withHeader(HttpConstants.HEADER_AUTHORIZATION, matching(".*"))
+                .willReturn(WireMock.aResponse()
+                        .withHeader(HttpConstants.HEADER_CONTENT_TYPE, HttpConstants.MEDIA_TYPE_TEXT_TURTLE)
+                        .withBody("TURTLE-DPOP")));
+
+        wireMockServer.stubFor(WireMock.get(WireMock.urlEqualTo("/get/turtle"))
+                .withHeader(HttpConstants.HEADER_AUTHORIZATION, containing(HttpConstants.PREFIX_BEARER))
+                .willReturn(WireMock.aResponse()
+                        .withHeader(HttpConstants.HEADER_CONTENT_TYPE, HttpConstants.MEDIA_TYPE_TEXT_TURTLE)
+                        .withBody("TURTLE-BEARER")));
+
+        wireMockServer.stubFor(WireMock.put(WireMock.urlEqualTo("/put"))
+                .withHeader(HttpConstants.HEADER_CONTENT_TYPE, containing(HttpConstants.MEDIA_TYPE_TEXT_PLAIN))
+                .withRequestBody(containing("TEXT"))
+                .willReturn(WireMock.aResponse().withStatus(200)));
+
+        wireMockServer.stubFor(WireMock.put(WireMock.urlEqualTo("/put"))
+                .withHeader(HttpConstants.HEADER_CONTENT_TYPE, containing(HttpConstants.MEDIA_TYPE_TEXT_TURTLE))
+                .withRequestBody(containing("TURTLE"))
+                .willReturn(WireMock.aResponse().withStatus(201)));
+
+        wireMockServer.stubFor(WireMock.head(WireMock.urlEqualTo("/head"))
+                .willReturn(WireMock.aResponse()
+                        .withHeader("HEADER", "VALUE1", "VALUE2")
+                        .withStatus(200)));
+
+        wireMockServer.stubFor(WireMock.delete(WireMock.urlEqualTo("/delete"))
+                .willReturn(WireMock.aResponse().withStatus(204)));
+
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public void stop() {
+        if (null != wireMockServer) {
+            wireMockServer.stop();
+        }
+    }
+
+    @Override
+    public void inject(final Object testInstance) {
+        // pass the wiremock base uri back into the test
+        if (testInstance instanceof ClientTest) {
+            ((ClientTest) testInstance).setBaseUri(URI.create(wireMockServer.baseUrl() + "/"));
+        }
+    }
+}

--- a/src/test/java/org/solid/testharness/http/ClientTest.java
+++ b/src/test/java/org/solid/testharness/http/ClientTest.java
@@ -1,0 +1,267 @@
+package org.solid.testharness.http;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import org.jose4j.lang.JoseException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.solid.testharness.utils.TestData;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+@QuarkusTestResource(ClientResource.class)
+class ClientTest {
+    private URI baseUri;
+
+    @BeforeEach
+    void setup() {
+        System.clearProperty("jdk.internal.httpclient.disableHostnameVerification");
+    }
+
+    @Test
+    void buildSimple() {
+        final Client client = new Client.Builder().build();
+        assertEquals("Client: user=, dPoP=false, session=false, local=false", client.toString());
+    }
+
+    @Test
+    void buildWithUser() {
+        final Client client = new Client.Builder("user").build();
+        assertEquals("Client: user=user, dPoP=false, session=false, local=false", client.toString());
+    }
+
+    @Test
+    void buildWithSessionSupport() {
+        final Client client = new Client.Builder("session").withSessionSupport().build();
+        assertEquals("Client: user=session, dPoP=false, session=true, local=false", client.toString());
+    }
+
+    @Test
+    void buildWithLocalhostSUpport() {
+        final Client client = new Client.Builder("local").withLocalhostSupport().build();
+        assertEquals("Client: user=local, dPoP=false, session=false, local=true", client.toString());
+    }
+
+    @Test
+    void buildWithDpopSupport() throws Exception {
+        final Client client = new Client.Builder("dpop").withDpopSupport().build();
+        assertEquals("Client: user=dpop, dPoP=true, session=false, local=false", client.toString());
+    }
+
+
+    @Test
+    void getHttpClient() {
+        final Client client = new Client.Builder().build();
+        assertNotNull(client.getHttpClient());
+    }
+
+    @Test
+    void getSetAccessToken() {
+        final Client client = new Client.Builder().build();
+        assertNull(client.getAccessToken());
+        client.setAccessToken("ACCESS");
+        assertEquals("ACCESS", client.getAccessToken());
+    }
+
+    @Test
+    void getUser() {
+        final Client client = new Client.Builder("testuser").build();
+        assertEquals("testuser", client.getUser());
+    }
+
+    @Test
+    void send() throws IOException, InterruptedException {
+        final Client client = new Client.Builder().build();
+        final HttpRequest request = HttpRequest.newBuilder(baseUri.resolve("/get/404")).build();
+        final HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(404, response.statusCode());
+    }
+
+    @Test
+    void sendNullRequest() {
+        final Client client = new Client.Builder().build();
+        assertThrows(NullPointerException.class, () -> client.send(null, HttpResponse.BodyHandlers.ofString()));
+    }
+
+    @Test
+    void sendNullHandler() {
+        final Client client = new Client.Builder().build();
+        final HttpRequest request = HttpRequest.newBuilder(baseUri).build();
+        assertThrows(NullPointerException.class, () -> client.send(request, null));
+    }
+
+    @Test
+    void sendFail() {
+        final Client client = new Client.Builder().build();
+        final HttpRequest request = HttpRequest.newBuilder(baseUri.resolve("/get/fault")).build();
+        assertThrows(IOException.class, () -> client.send(request, HttpResponse.BodyHandlers.ofString()));
+    }
+
+    @Test
+    void getAsTurtleNoAuth() throws Exception {
+        final Client client = new Client.Builder().build();
+        final HttpResponse<String> response = client.getAsTurtle(baseUri.resolve("/get/turtle"));
+        assertEquals("TURTLE-NOAUTH", response.body());
+    }
+
+    @Test
+    void getAsTurtleDpop() throws Exception {
+        final Client client = new Client.Builder().withDpopSupport().build();
+        client.setAccessToken("ACCESS");
+        final HttpResponse<String> response = client.getAsTurtle(baseUri.resolve("/get/turtle"));
+        assertEquals("TURTLE-DPOP", response.body());
+    }
+
+    @Test
+    void getAsTurtleBearer() throws Exception {
+        final Client client = new Client.Builder().build();
+        client.setAccessToken("ACCESS");
+        final HttpResponse<Void> response = client.put(baseUri.resolve("/put"), "TEXT",
+                HttpConstants.MEDIA_TYPE_TEXT_PLAIN);
+        assertEquals(200, response.statusCode());
+    }
+
+    @Test
+    void getAsTurtleNull() {
+        final Client client = new Client.Builder().build();
+        assertThrows(NullPointerException.class, () -> client.getAsTurtle(null));
+    }
+
+    @Test
+    void putText() throws Exception {
+        final Client client = new Client.Builder().build();
+        final HttpResponse<Void> response = client.put(baseUri.resolve("/put"), "TEXT",
+                HttpConstants.MEDIA_TYPE_TEXT_PLAIN);
+        assertEquals(200, response.statusCode());
+    }
+
+    @Test
+    void putTurtle() throws Exception {
+        final Client client = new Client.Builder().build();
+        final HttpResponse<Void> response = client.put(baseUri.resolve("/put"), "TURTLE",
+                HttpConstants.MEDIA_TYPE_TEXT_TURTLE);
+        assertEquals(201, response.statusCode());
+    }
+
+    @Test
+    void putNullUrl() {
+        final Client client = new Client.Builder().build();
+        assertThrows(NullPointerException.class, () -> client.put(null, "", ""));
+    }
+
+    @Test
+    void putNullData() {
+        final Client client = new Client.Builder().build();
+        assertThrows(NullPointerException.class, () -> client.put(baseUri, null, ""));
+    }
+
+    @Test
+    void putNullType() {
+        final Client client = new Client.Builder().build();
+        assertThrows(NullPointerException.class, () -> client.put(baseUri, "DATA", null));
+    }
+
+    @Test
+    void head() throws IOException, InterruptedException {
+        final Client client = new Client.Builder().build();
+        final HttpResponse<Void> response = client.head(baseUri.resolve("/head"));
+        assertEquals(200, response.statusCode());
+        assertEquals(2, response.headers().allValues("HEADER").size());
+        assertEquals("VALUE1", response.headers().allValues("HEADER").get(0));
+    }
+
+    @Test
+    void headNullUrl() {
+        final Client client = new Client.Builder().build();
+        assertThrows(NullPointerException.class, () -> client.head(null));
+    }
+
+    @Test
+    void deleteAsync() throws ExecutionException, InterruptedException {
+        final Client client = new Client.Builder().build();
+        final CompletableFuture<HttpResponse<Void>> futureResponse = client.deleteAsync(baseUri.resolve("/delete"));
+        assertNotNull(futureResponse);
+        final HttpResponse<Void> response = futureResponse.get();
+        assertEquals(204, response.statusCode());
+    }
+
+    @Test
+    void deleteAsyncNull() {
+        final Client client = new Client.Builder().build();
+        assertThrows(NullPointerException.class, () -> client.deleteAsync(null));
+    }
+
+    @Test
+    void signRequestNoDpop() {
+        final Client client = new Client.Builder().build();
+        final HttpRequest.Builder builder = HttpRequest.newBuilder(URI.create(TestData.SAMPLE_BASE));
+        final HttpRequest request = client.signRequest(builder).build();
+        assertFalse(request.headers().map().containsKey(HttpConstants.HEADER_DPOP));
+    }
+
+    @Test
+    void signRequest() throws JoseException {
+        final Client client = new Client.Builder().withDpopSupport().build();
+        final HttpRequest.Builder builder = HttpRequest.newBuilder(URI.create(TestData.SAMPLE_BASE));
+        final HttpRequest request = client.signRequest(builder).build();
+        assertTrue(request.headers().map().containsKey(HttpConstants.HEADER_DPOP));
+    }
+
+    @Test
+    void signRequestNull() {
+        final Client client = new Client.Builder().build();
+        assertThrows(NullPointerException.class, () -> client.signRequest(null));
+    }
+
+    @Test
+    void getAuthHeadersNoAccessToken() {
+        final Client client = new Client.Builder().build();
+        assertTrue(client.getAuthHeaders("GET", TestData.SAMPLE_BASE).isEmpty());
+    }
+
+    @Test
+    void getAuthHeadersNoDpop() {
+        final Client client = new Client.Builder().build();
+        client.setAccessToken("ACCESS");
+        final Map<String, String> headers = client.getAuthHeaders("GET", TestData.SAMPLE_BASE);
+        assertTrue(headers.containsKey(HttpConstants.HEADER_AUTHORIZATION));
+        assertTrue(headers.get(HttpConstants.HEADER_AUTHORIZATION).startsWith(HttpConstants.PREFIX_BEARER));
+        assertTrue(headers.containsKey(HttpConstants.USER_AGENT));
+    }
+
+    @Test
+    void getAuthHeadersDpop() throws JoseException {
+        final Client client = new Client.Builder().withDpopSupport().build();
+        client.setAccessToken("ACCESS");
+        final Map<String, String> headers = client.getAuthHeaders("GET", TestData.SAMPLE_BASE);
+        assertTrue(headers.containsKey(HttpConstants.HEADER_AUTHORIZATION));
+        assertTrue(headers.get(HttpConstants.HEADER_AUTHORIZATION).startsWith(HttpConstants.PREFIX_DPOP));
+        assertTrue(headers.containsKey(HttpConstants.HEADER_DPOP));
+        assertTrue(headers.containsKey(HttpConstants.USER_AGENT));
+    }
+
+    @Test
+    void getAuthHeadersNullMethod() {
+        final Client client = new Client.Builder().build();
+        assertThrows(NullPointerException.class, () -> client.getAuthHeaders(null, ""));
+    }
+
+    @Test
+    void getAuthHeadersNullUri() {
+        final Client client = new Client.Builder().build();
+        assertThrows(NullPointerException.class, () -> client.getAuthHeaders("GET", null));
+    }
+
+    public void setBaseUri(final URI baseUri) {
+        this.baseUri = baseUri;
+    }
+}

--- a/src/test/java/org/solid/testharness/http/HttpClientTest.java
+++ b/src/test/java/org/solid/testharness/http/HttpClientTest.java
@@ -33,14 +33,14 @@ class HttpClientTest {
                 URI.create("https://solid-test-suite-alice.inrupt.net")
         ).build();
         HttpResponse<Void> response = client.send(request, HttpResponse.BodyHandlers.discarding());
-        List<String> links = response.headers().allValues("Link");
+        List<String> links = response.headers().allValues(HttpConstants.HEADER_LINK);
         logger.debug("NSS links {}: {}", links.size(), links);
 
         request = HttpUtils.newRequestBuilder(
                 URI.create("https://pod-compat.inrupt.com/solid-test-suite-alice/profile/card#me")
         ).build();
         response = client.send(request, HttpResponse.BodyHandlers.discarding());
-        links = response.headers().allValues("Link");
+        links = response.headers().allValues(HttpConstants.HEADER_LINK);
         logger.debug("ESS links {}: {}", links.size(), links);
     }
 

--- a/src/test/java/org/solid/testharness/http/HttpUtilsTest.java
+++ b/src/test/java/org/solid/testharness/http/HttpUtilsTest.java
@@ -1,0 +1,336 @@
+package org.solid.testharness.http;
+
+import jakarta.ws.rs.core.Link;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.slf4j.Logger;
+
+import java.net.URI;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class HttpUtilsTest {
+
+    @Test
+    void getAgentDefault() {
+        System.clearProperty("agent");
+        assertEquals("Solid-Conformance-Test-Suite", HttpUtils.getAgent());
+        System.getProperty("agent", "Solid-Conformance-Test-Suite");
+    }
+
+    @Test
+    void getAgent() {
+        System.setProperty("agent", "Agent");
+        assertEquals("Agent", HttpUtils.getAgent());
+    }
+
+    @Test
+    void newRequestBuilder() {
+        System.setProperty("agent", "TestAgent");
+        final HttpRequest request = HttpUtils.newRequestBuilder(URI.create("http://example.org")).build();
+        assertEquals("TestAgent", request.headers().firstValue(HttpConstants.USER_AGENT).get());
+    }
+
+    @Test
+    void isSuccessful() {
+        assertTrue(HttpUtils.isSuccessful(200));
+        assertTrue(HttpUtils.isSuccessful(299));
+        assertFalse(HttpUtils.isSuccessful(199));
+        assertFalse(HttpUtils.isSuccessful(300));
+    }
+
+    @Test
+    void isRedirect() {
+        assertTrue(HttpUtils.isRedirect(302));
+        assertFalse(HttpUtils.isRedirect(200));
+    }
+
+    @Test
+    void isSuccessfulOrRedirect() {
+        assertTrue(HttpUtils.isSuccessfulOrRedirect(200));
+        assertTrue(HttpUtils.isSuccessfulOrRedirect(399));
+        assertFalse(HttpUtils.isSuccessfulOrRedirect(199));
+        assertFalse(HttpUtils.isSuccessfulOrRedirect(400));
+    }
+
+    @Test
+    void isHttpProtocol() {
+        assertTrue(HttpUtils.isHttpProtocol("http"));
+        assertTrue(HttpUtils.isHttpProtocol("https"));
+        assertFalse(HttpUtils.isHttpProtocol("ws"));
+        assertFalse(HttpUtils.isHttpProtocol(null));
+    }
+
+    @Test
+    void isFileProtocol() {
+        assertTrue(HttpUtils.isFileProtocol("file"));
+        assertFalse(HttpUtils.isFileProtocol("files"));
+        assertFalse(HttpUtils.isFileProtocol(null));
+    }
+
+    @Test
+    void logRequestDisabled() {
+        final Logger logger = mock(Logger.class);
+        final HttpRequest request = mock(HttpRequest.class);
+        when(logger.isDebugEnabled()).thenReturn(false);
+        HttpUtils.logRequest(logger, request);
+        verify(logger, never()).debug(anyString(), ArgumentMatchers.<Object>any());
+    }
+
+    @Test
+    void logRequest() {
+        final Logger logger = mock(Logger.class);
+        when(logger.isDebugEnabled()).thenReturn(true);
+        final HttpRequest request = HttpRequest.newBuilder(URI.create("https://example.org/"))
+                .header("key", "value")
+                .build();
+        HttpUtils.logRequest(logger, request);
+        verify(logger).isDebugEnabled();
+        verify(logger, times(2)).debug(anyString(), anyString(), any());
+        verifyNoMoreInteractions(logger);
+    }
+
+    @Test
+    void logResponsetDisabled() {
+        final Logger logger = mock(Logger.class);
+        final HttpResponse<String> response = mock(HttpResponse.class);
+        when(logger.isDebugEnabled()).thenReturn(false);
+        HttpUtils.logResponse(logger, response);
+        verify(logger, never()).debug(anyString(), ArgumentMatchers.<Object>any());
+    }
+
+    @Test
+    void logResponse() {
+        final Logger logger = mock(Logger.class);
+        final HttpRequest request = HttpRequest.newBuilder(URI.create("https://example.org/")).build();
+        final HttpResponse<String> response = mock(HttpResponse.class);
+        when(logger.isDebugEnabled()).thenReturn(true);
+        when(response.request()).thenReturn(request);
+        when(response.uri()).thenReturn(URI.create("https://example.org/"));
+        when(response.statusCode()).thenReturn(400);
+        when(response.headers()).thenReturn(setupHeaders("key", List.of("value")));
+        when(response.body()).thenReturn("BODY");
+        HttpUtils.logResponse(logger, response);
+        verify(logger).isDebugEnabled();
+        verify(logger, times(2)).debug(anyString(), anyString(), any());
+        verify(logger, times(1)).debug(anyString(), eq(400));
+        verify(logger, times(1)).debug(anyString(), eq("BODY"));
+        verifyNoMoreInteractions(logger);
+    }
+
+    @Test
+    void logResponseVoid() {
+        final Logger logger = mock(Logger.class);
+        final HttpRequest request = HttpRequest.newBuilder(URI.create("https://example.org/")).build();
+        final HttpResponse<Void> response = mock(HttpResponse.class);
+        when(logger.isDebugEnabled()).thenReturn(true);
+        when(response.request()).thenReturn(request);
+        when(response.uri()).thenReturn(URI.create("https://example.org/"));
+        when(response.statusCode()).thenReturn(400);
+        when(response.headers()).thenReturn(setupHeaders("key", List.of("value")));
+        when(response.body()).thenReturn(null);
+        HttpUtils.logResponse(logger, response);
+        verify(logger).isDebugEnabled();
+        verify(logger, times(2)).debug(anyString(), anyString(), any());
+        verify(logger, times(1)).debug(anyString(), eq(400));
+        verifyNoMoreInteractions(logger);
+    }
+
+    @Test
+    void ofFormDataSingle() {
+        assertEquals(4, HttpUtils.ofFormData(Map.of("ab", 1)).contentLength());
+    }
+
+    @Test
+    void ofFormDataMulti() {
+        assertEquals(9, HttpUtils.ofFormData(Map.of("ab", 1, "cd", "2")).contentLength());
+    }
+
+    @Test
+    void ofFormDataEmpty() {
+        assertEquals(0, HttpUtils.ofFormData(Collections.emptyMap()).contentLength());
+    }
+
+    @Test
+    void ofFormDataNull() {
+        assertThrows(NullPointerException.class, () -> HttpUtils.ofFormData(null));
+    }
+
+    @Test
+    void encodeValue() {
+        assertEquals("a+b", HttpUtils.encodeValue("a b"));
+    }
+
+    @Test
+    void encodeValueNull() {
+        assertThrows(NullPointerException.class, () -> HttpUtils.encodeValue(null));
+    }
+
+    @Test
+    void splitQueryNull() {
+        assertTrue(HttpUtils.splitQuery(null).isEmpty());
+    }
+
+    @Test
+    void splitQueryNoQuery() {
+        assertTrue(HttpUtils.splitQuery(URI.create("https://example.org/")).isEmpty());
+    }
+
+    @Test
+    void splitQueryEmptyQuery() {
+        assertTrue(HttpUtils.splitQuery(URI.create("https://example.org/?")).isEmpty());
+    }
+
+    @Test
+    void splitQuerySingle() {
+        final Map<String, List<String>> parts = HttpUtils.splitQuery(URI.create("https://example.org/?a=1"));
+        assertFalse(parts.isEmpty());
+        assertEquals(1, parts.keySet().size());
+        assertTrue(parts.containsKey("a"));
+        assertEquals(1, parts.get("a").size());
+        assertEquals("1", parts.get("a").get(0));
+    }
+
+    @Test
+    void splitQuerySingleList() {
+        final Map<String, List<String>> parts = HttpUtils.splitQuery(URI.create("https://example.org/?a=1&a=2"));
+        assertFalse(parts.isEmpty());
+        assertEquals(1, parts.keySet().size());
+        assertTrue(parts.containsKey("a"));
+        assertEquals(2, parts.get("a").size());
+        assertEquals("1", parts.get("a").get(0));
+        assertEquals("2", parts.get("a").get(1));
+    }
+
+    @Test
+    void splitQueryMultiple() {
+        final Map<String, List<String>> parts = HttpUtils.splitQuery(URI.create("https://example.org/?a=1&b=2"));
+        assertFalse(parts.isEmpty());
+        assertEquals(2, parts.keySet().size());
+        assertTrue(parts.containsKey("a"));
+        assertEquals(1, parts.get("a").size());
+        assertEquals("1", parts.get("a").get(0));
+        assertTrue(parts.containsKey("b"));
+        assertEquals(1, parts.get("b").size());
+        assertEquals("2", parts.get("b").get(0));
+    }
+
+    @Test
+    void splitQueryKeyNoValue() {
+        final Map<String, List<String>> parts = HttpUtils.splitQuery(URI.create("https://example.org/?a="));
+        assertFalse(parts.isEmpty());
+        assertEquals(1, parts.keySet().size());
+        assertTrue(parts.containsKey("a"));
+        assertEquals(1, parts.get("a").size());
+        assertNull(parts.get("a").get(0));
+    }
+
+    @Test
+    void splitQueryKeyOnly() {
+        final Map<String, List<String>> parts = HttpUtils.splitQuery(URI.create("https://example.org/?a"));
+        assertFalse(parts.isEmpty());
+        assertEquals(1, parts.keySet().size());
+        assertTrue(parts.containsKey("a"));
+        assertEquals(1, parts.get("a").size());
+        assertNull(parts.get("a").get(0));
+    }
+
+    @Test
+    void parseLinkHeaders() {
+        final List<Link> links = HttpUtils.parseLinkHeaders(setupHeaders(HttpConstants.HEADER_LINK,
+                List.of("<https://example.org/next>; rel=\"next\"")));
+        assertEquals(1, links.size());
+        assertEquals(URI.create("https://example.org/next"), links.get(0).getUri());
+        assertEquals("next", links.get(0).getRel());
+    }
+
+    @Test
+    void parseLinkHeadersTwoInOne() {
+        final List<Link> links = HttpUtils.parseLinkHeaders(setupHeaders(HttpConstants.HEADER_LINK,
+                List.of("<https://example.org/next>; rel=\"next\", <https://example.org/last>; rel=\"last\"")));
+        assertEquals(2, links.size());
+        assertEquals(URI.create("https://example.org/next"), links.get(0).getUri());
+        assertEquals("next", links.get(0).getRel());
+        assertEquals(URI.create("https://example.org/last"), links.get(1).getUri());
+        assertEquals("last", links.get(1).getRel());
+    }
+
+    @Test
+    void parseLinkHeadersTwo() {
+        final List<Link> links = HttpUtils.parseLinkHeaders(setupHeaders(HttpConstants.HEADER_LINK,
+                List.of("<https://example.org/next>; rel=\"next\"", "<https://example.org/last>; rel=\"last\"")));
+        assertEquals(URI.create("https://example.org/next"), links.get(0).getUri());
+        assertEquals("next", links.get(0).getRel());
+        assertEquals(URI.create("https://example.org/last"), links.get(1).getUri());
+        assertEquals("last", links.get(1).getRel());
+    }
+
+    @Test
+    void parseLinkHeadersNoLink() {
+        assertTrue(HttpUtils.parseLinkHeaders(setupHeaders("NotLink", List.of("something"))).isEmpty());
+    }
+
+    @Test
+    void parseLinkHeadersNull() {
+        assertThrows(NullPointerException.class, () -> HttpUtils.parseLinkHeaders(null));
+    }
+
+    @Test
+    void parseWacAllowHeader() {
+        final Map<String, List<String>> header = HttpUtils.parseWacAllowHeader(
+                Map.of(HttpConstants.HEADER_WAC_ALLOW, List.of("user=\"read write\", public=\"read\""))
+        );
+        assertEquals(2, header.get("user").size());
+        assertEquals("read", header.get("user").get(0));
+        assertEquals("write", header.get("user").get(1));
+        assertEquals(1, header.get("public").size());
+        assertEquals("read", header.get("public").get(0));
+    }
+
+    @Test
+    void parseWacAllowHeaderEmptyGroup() {
+        final Map<String, List<String>> header = HttpUtils.parseWacAllowHeader(
+                Map.of(HttpConstants.HEADER_WAC_ALLOW, List.of("user=\"read\", public="))
+        );
+        assertEquals(1, header.get("user").size());
+        assertEquals("read", header.get("user").get(0));
+        assertTrue(header.get("public").isEmpty());
+    }
+
+    @Test
+    void parseWacAllowHeaderNewGroup() {
+        final Map<String, List<String>> header = HttpUtils.parseWacAllowHeader(
+                Map.of(HttpConstants.HEADER_WAC_ALLOW, List.of("user=\"read\", internal=\"append\""))
+        );
+        assertEquals(1, header.get("user").size());
+        assertEquals("read", header.get("user").get(0));
+        assertTrue(header.get("public").isEmpty());
+        assertEquals(1, header.get("internal").size());
+        assertEquals("append", header.get("internal").get(0));
+    }
+
+    @Test
+    void parseWacAllowHeaderMissing() {
+        final Map<String, List<String>> header = HttpUtils.parseWacAllowHeader(
+                Map.of("NotWacAllow", List.of("something"))
+        );
+        assertTrue(header.get("user").isEmpty());
+        assertTrue(header.get("public").isEmpty());
+    }
+
+    @Test
+    void parseWacAllowHeaderNull() {
+        assertThrows(NullPointerException.class, () -> HttpUtils.parseWacAllowHeader(null));
+    }
+
+    private HttpHeaders setupHeaders(final String name, final List<String> values) {
+        return HttpHeaders.of(Map.of(name, values), (k, v) -> true);
+    }
+}

--- a/src/test/java/org/solid/testharness/http/OidcConfigurationTest.java
+++ b/src/test/java/org/solid/testharness/http/OidcConfigurationTest.java
@@ -1,0 +1,62 @@
+package org.solid.testharness.http;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+class OidcConfigurationTest {
+    private static final String DATA = "{\"authorization_endpoint\":\"https://example.org/authorization\"," +
+            "\"issuer\":\"https://example.org\"," +
+            "\"registration_endpoint\":\"https://example.org/registration\"," +
+            "\"token_endpoint\":\"https://example.org/token\"" +
+            "}";
+
+    @Inject
+    ObjectMapper objectMapper;
+
+    private OidcConfiguration oidcConfiguration;
+
+    @BeforeEach
+    void setup() throws JsonProcessingException {
+        oidcConfiguration = objectMapper.readValue(DATA, OidcConfiguration.class);
+    }
+
+    @Test
+    void getIssuer() {
+        assertEquals("https://example.org/", oidcConfiguration.getIssuer());
+    }
+
+    @Test
+    void getIssuerWithSlash() {
+        oidcConfiguration.setIssuer("https://example.org/");
+        assertEquals("https://example.org/", oidcConfiguration.getIssuer());
+    }
+
+    @Test
+    void getIssuerNull() {
+        oidcConfiguration.setIssuer(null);
+        assertEquals(null, oidcConfiguration.getIssuer());
+    }
+
+    @Test
+    void getAuthorizeEndpoint() {
+        assertEquals("https://example.org/authorization", oidcConfiguration.getAuthorizeEndpoint());
+    }
+
+    @Test
+    void getTokenEndpoint() {
+        assertEquals("https://example.org/token", oidcConfiguration.getTokenEndpoint());
+    }
+
+    @Test
+    void getRegistrationEndpoint() {
+        assertEquals("https://example.org/registration", oidcConfiguration.getRegistrationEndpoint());
+    }
+}

--- a/src/test/java/org/solid/testharness/http/SolidClientTest.java
+++ b/src/test/java/org/solid/testharness/http/SolidClientTest.java
@@ -121,7 +121,7 @@ class SolidClientTest {
     void getResourceAclLink() throws IOException, InterruptedException {
         final Client mockClient = mock(Client.class);
         final HttpResponse<Void> mockResponse = mock(HttpResponse.class);
-        final Map<String, List<String>> headerMap = Map.of("Link",
+        final Map<String, List<String>> headerMap = Map.of(HttpConstants.HEADER_LINK,
                 List.of("<http://localhost:3000/test.acl>; rel=\"acl\""));
         final HttpHeaders mockHeaders = HttpHeaders.of(headerMap, (k, v) -> true);
         when(mockResponse.headers()).thenReturn(mockHeaders);
@@ -163,7 +163,7 @@ class SolidClientTest {
 
     @Test
     void getAclLinkMultiple() {
-        final Map<String, List<String>> headerMap = Map.of("Link", List.of(
+        final Map<String, List<String>> headerMap = Map.of(HttpConstants.HEADER_LINK, List.of(
                 "<http://localhost:3000/test.acl>; rel=\"acl\"",
                 "<http://localhost:3000/test.acl2>; rel=\"acl\""
                 ));
@@ -213,11 +213,11 @@ class SolidClientTest {
         final URI resourceAcl = URI.create("http://localhost:3000/test");
         final HttpResponse<String> mockResponse = mockStringResponse(200, "TEST");
 
-        when(mockClient.getAsString(eq(resourceAcl))).thenReturn(mockResponse);
+        when(mockClient.getAsTurtle(eq(resourceAcl))).thenReturn(mockResponse);
 
         final SolidClient solidClient = new SolidClient(mockClient);
         assertEquals("TEST", solidClient.getContainmentData(resourceAcl));
-        verify(mockClient).getAsString(resourceAcl);
+        verify(mockClient).getAsTurtle(resourceAcl);
     }
 
     @Test
@@ -226,7 +226,7 @@ class SolidClientTest {
         final URI resourceAcl = URI.create("http://localhost:3000/test");
         final HttpResponse<String> mockResponse = mockStringResponse(500, null);
 
-        when(mockClient.getAsString(eq(resourceAcl))).thenReturn(mockResponse);
+        when(mockClient.getAsTurtle(eq(resourceAcl))).thenReturn(mockResponse);
 
         final SolidClient solidClient = new SolidClient(mockClient);
         final Exception exception = assertThrows(Exception.class, () -> solidClient.getContainmentData(resourceAcl));
@@ -284,7 +284,7 @@ class SolidClientTest {
         final HttpResponse<String> mockResponse = mockStringResponse(200, data);
         final HttpResponse<Void> mockResponseOk = mockVoidResponse(200);
 
-        when(mockClient.getAsString(eq(URI.create("http://localhost:3000/")))).thenReturn(mockResponse);
+        when(mockClient.getAsTurtle(eq(URI.create("http://localhost:3000/")))).thenReturn(mockResponse);
         when(mockClient.deleteAsync(URI.create("http://localhost:3000/test")))
                 .thenReturn(CompletableFuture.supplyAsync(() -> mockResponseOk));
         when(mockClient.deleteAsync(URI.create("http://localhost:3000/test2")))
@@ -292,7 +292,7 @@ class SolidClientTest {
 
         final SolidClient solidClient = new SolidClient(mockClient);
         assertDoesNotThrow(() -> solidClient.deleteContentsRecursively(URI.create("http://localhost:3000/")));
-        verify(mockClient).getAsString(URI.create("http://localhost:3000/"));
+        verify(mockClient).getAsTurtle(URI.create("http://localhost:3000/"));
         verify(mockClient).deleteAsync(URI.create("http://localhost:3000/test"));
         verify(mockClient).deleteAsync(URI.create("http://localhost:3000/test2"));
         verifyNoMoreInteractions(mockClient);
@@ -307,7 +307,7 @@ class SolidClientTest {
         final HttpResponse<Void> mockResponseOk = mockVoidResponse(200);
         final HttpResponse<Void> mockResponseFail = mockVoidResponse(500);
 
-        when(mockClient.getAsString(eq(URI.create("http://localhost:3000/")))).thenReturn(mockResponse);
+        when(mockClient.getAsTurtle(eq(URI.create("http://localhost:3000/")))).thenReturn(mockResponse);
         when(mockClient.deleteAsync(URI.create("http://localhost:3000/test")))
                 .thenReturn(CompletableFuture.supplyAsync(() -> mockResponseOk));
         when(mockClient.deleteAsync(URI.create("http://localhost:3000/test2")))
@@ -315,7 +315,7 @@ class SolidClientTest {
 
         final SolidClient solidClient = new SolidClient(mockClient);
         assertDoesNotThrow(() -> solidClient.deleteContentsRecursively(URI.create("http://localhost:3000/")));
-        verify(mockClient).getAsString(URI.create("http://localhost:3000/"));
+        verify(mockClient).getAsTurtle(URI.create("http://localhost:3000/"));
         verify(mockClient).deleteAsync(URI.create("http://localhost:3000/test"));
         verify(mockClient).deleteAsync(URI.create("http://localhost:3000/test2"));
         verifyNoMoreInteractions(mockClient);
@@ -333,7 +333,7 @@ class SolidClientTest {
         // resources which may fail. Better handling needed.
         when(mockResponseException.statusCode()).thenThrow(new RuntimeException("FAIL"));
 
-        when(mockClient.getAsString(eq(URI.create("http://localhost:3000/")))).thenReturn(mockResponse);
+        when(mockClient.getAsTurtle(eq(URI.create("http://localhost:3000/")))).thenReturn(mockResponse);
         when(mockClient.deleteAsync(URI.create("http://localhost:3000/test")))
                 .thenReturn(CompletableFuture.supplyAsync(() -> mockResponseOk));
         when(mockClient.deleteAsync(URI.create("http://localhost:3000/test2")))
@@ -343,7 +343,7 @@ class SolidClientTest {
 
         final SolidClient solidClient = new SolidClient(mockClient);
         assertDoesNotThrow(() -> solidClient.deleteResourceRecursively(URI.create("http://localhost:3000/")));
-        verify(mockClient).getAsString(URI.create("http://localhost:3000/"));
+        verify(mockClient).getAsTurtle(URI.create("http://localhost:3000/"));
         verify(mockClient).deleteAsync(URI.create("http://localhost:3000/test"));
         verify(mockClient).deleteAsync(URI.create("http://localhost:3000/test2"));
         verify(mockClient).deleteAsync(URI.create("http://localhost:3000/"));
@@ -356,11 +356,11 @@ class SolidClientTest {
         final Client mockClient = mock(Client.class);
         final HttpResponse<String> mockResponse = mockStringResponse(500, null);
 
-        when(mockClient.getAsString(eq(URI.create("http://localhost:3000/")))).thenReturn(mockResponse);
+        when(mockClient.getAsTurtle(eq(URI.create("http://localhost:3000/")))).thenReturn(mockResponse);
 
         final SolidClient solidClient = new SolidClient(mockClient);
         assertDoesNotThrow(() -> solidClient.deleteResourceRecursively(URI.create("http://localhost:3000/")));
-        verify(mockClient).getAsString(URI.create("http://localhost:3000/"));
+        verify(mockClient).getAsTurtle(URI.create("http://localhost:3000/"));
         verifyNoMoreInteractions(mockClient);
     }
 
@@ -372,7 +372,7 @@ class SolidClientTest {
         final HttpResponse<String> mockResponse = mockStringResponse(200, data);
         final HttpResponse<Void> mockResponseOk = mockVoidResponse(200);
 
-        when(mockClient.getAsString(eq(URI.create("http://localhost:3000/")))).thenReturn(mockResponse);
+        when(mockClient.getAsTurtle(eq(URI.create("http://localhost:3000/")))).thenReturn(mockResponse);
         when(mockClient.deleteAsync(URI.create("http://localhost:3000/test")))
                 .thenReturn(CompletableFuture.supplyAsync(() -> mockResponseOk));
         when(mockClient.deleteAsync(URI.create("http://localhost:3000/test2")))
@@ -382,7 +382,7 @@ class SolidClientTest {
 
         final SolidClient solidClient = new SolidClient(mockClient);
         assertDoesNotThrow(() -> solidClient.deleteResourceRecursively(URI.create("http://localhost:3000/")));
-        verify(mockClient).getAsString(URI.create("http://localhost:3000/"));
+        verify(mockClient).getAsTurtle(URI.create("http://localhost:3000/"));
         verify(mockClient).deleteAsync(URI.create("http://localhost:3000/test"));
         verify(mockClient).deleteAsync(URI.create("http://localhost:3000/test2"));
         verify(mockClient).deleteAsync(URI.create("http://localhost:3000/"));
@@ -400,8 +400,8 @@ class SolidClientTest {
         final HttpResponse<String> mockResponseChild = mockStringResponse(200, data2);
         final HttpResponse<Void> mockResponseOk = mockVoidResponse(200);
 
-        when(mockClient.getAsString(eq(URI.create("http://localhost:3000/")))).thenReturn(mockResponse);
-        when(mockClient.getAsString(eq(URI.create("http://localhost:3000/child/")))).thenReturn(mockResponseChild);
+        when(mockClient.getAsTurtle(eq(URI.create("http://localhost:3000/")))).thenReturn(mockResponse);
+        when(mockClient.getAsTurtle(eq(URI.create("http://localhost:3000/child/")))).thenReturn(mockResponseChild);
         when(mockClient.deleteAsync(URI.create("http://localhost:3000/test")))
                 .thenReturn(CompletableFuture.supplyAsync(() -> mockResponseOk));
         when(mockClient.deleteAsync(URI.create("http://localhost:3000/test2")))
@@ -415,8 +415,8 @@ class SolidClientTest {
 
         final SolidClient solidClient = new SolidClient(mockClient);
         assertDoesNotThrow(() -> solidClient.deleteResourceRecursively(URI.create("http://localhost:3000/")));
-        verify(mockClient).getAsString(URI.create("http://localhost:3000/"));
-        verify(mockClient).getAsString(URI.create("http://localhost:3000/child/"));
+        verify(mockClient).getAsTurtle(URI.create("http://localhost:3000/"));
+        verify(mockClient).getAsTurtle(URI.create("http://localhost:3000/child/"));
         verify(mockClient).deleteAsync(URI.create("http://localhost:3000/test"));
         verify(mockClient).deleteAsync(URI.create("http://localhost:3000/test2"));
         verify(mockClient).deleteAsync(URI.create("http://localhost:3000/test3"));

--- a/src/test/java/org/solid/testharness/reporting/AssertorTest.java
+++ b/src/test/java/org/solid/testharness/reporting/AssertorTest.java
@@ -1,0 +1,60 @@
+package org.solid.testharness.reporting;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+import org.solid.testharness.utils.AbstractDataModelTests;
+
+import java.time.LocalDate;
+
+import static org.eclipse.rdf4j.model.util.Values.iri;
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+class AssertorTest extends AbstractDataModelTests {
+    @Override
+    public String getTestFile() {
+        return "src/test/resources/assertor-testing-feature.ttl";
+    }
+
+    @Test
+    void getSoftwareName() {
+        final Assertor assertor = new Assertor(iri(NS, "tester1"));
+        assertEquals("TESTER1", assertor.getSoftwareName());
+    }
+
+    @Test
+    void getDescription() {
+        final Assertor assertor = new Assertor(iri(NS, "tester1"));
+        assertEquals("DESCRIPTION", assertor.getDescription());
+    }
+
+    @Test
+    void getCreatedDate() {
+        final Assertor assertor = new Assertor(iri(NS, "tester1"));
+        assertEquals(LocalDate.parse("2021-01-01"), assertor.getCreatedDate());
+    }
+
+    @Test
+    void getDeveloper() {
+        final Assertor assertor = new Assertor(iri(NS, "tester1"));
+        assertEquals("https://example.org/profile/card/#us", assertor.getDeveloper());
+    }
+
+    @Test
+    void getHomepage() {
+        final Assertor assertor = new Assertor(iri(NS, "tester1"));
+        assertEquals("https://example.org/tester", assertor.getHomepage());
+    }
+
+    @Test
+    void getRevision() {
+        final Assertor assertor = new Assertor(iri(NS, "tester1"));
+        assertEquals("0.0.1-SNAPSHOT", assertor.getRevision());
+    }
+
+    @Test
+    void getRevisionNull() {
+        final Assertor assertor = new Assertor(iri(NS, "tester2"));
+        assertNull(assertor.getRevision());
+    }
+}

--- a/src/test/java/org/solid/testharness/reporting/TestSuiteResultsTest.java
+++ b/src/test/java/org/solid/testharness/reporting/TestSuiteResultsTest.java
@@ -1,0 +1,39 @@
+package org.solid.testharness.reporting;
+
+import com.intuit.karate.Results;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class TestSuiteResultsTest {
+    @Test
+    void getErrorMessages() {
+        final Results results = mock(Results.class);
+        when(results.getErrorMessages()).thenReturn("ERRORS");
+        final TestSuiteResults testSuiteResults = new TestSuiteResults(results);
+        assertEquals("ERRORS", testSuiteResults.getErrorMessages());
+    }
+
+    @Test
+    void getFailCount() {
+        final Results results = mock(Results.class);
+        when(results.getFailCount()).thenReturn(1);
+        final TestSuiteResults testSuiteResults = new TestSuiteResults(results);
+        assertEquals(1, testSuiteResults.getFailCount());
+    }
+
+    @Test
+    void testToString() {
+        final Results results = mock(Results.class);
+        when(results.getFeaturesPassed()).thenReturn(1);
+        when(results.getFeaturesFailed()).thenReturn(2);
+        when(results.getFeaturesTotal()).thenReturn(3);
+        when(results.getScenariosPassed()).thenReturn(10);
+        when(results.getScenariosFailed()).thenReturn(20);
+        when(results.getScenariosTotal()).thenReturn(30);
+        final TestSuiteResults testSuiteResults = new TestSuiteResults(results);
+        assertEquals("Results:\n  Features  passed: 1, failed: 2, total: 3\n" +
+                "  Scenarios passed: 10, failed: 20, total: 30", testSuiteResults.toString());
+    }
+}

--- a/src/test/java/org/solid/testharness/utils/SolidResourceTest.java
+++ b/src/test/java/org/solid/testharness/utils/SolidResourceTest.java
@@ -66,7 +66,8 @@ class SolidResourceTest {
 
     @Test
     void resourceExistsWithAcl() throws Exception {
-        final Map<String, List<String>> headerMap = Map.of("Link", List.of("<" + aclUrl.toString() + ">; rel=\"acl\""));
+        final Map<String, List<String>> headerMap = Map.of(HttpConstants.HEADER_LINK,
+                List.of("<" + aclUrl.toString() + ">; rel=\"acl\""));
         final HttpHeaders headers = HttpHeaders.of(headerMap, (k, v) -> true);
         when(solidClient.createResource(testUrl, "hello", HttpConstants.MEDIA_TYPE_TEXT_PLAIN)).thenReturn(headers);
         when(solidClient.getAclLink(headers)).thenReturn(aclUrl);
@@ -81,7 +82,8 @@ class SolidResourceTest {
 
     @Test
     void resourceExistsWithoutAcl() throws Exception {
-        final Map<String, List<String>> headerMap = Map.of("Link", List.of("<" + aclUrl + ">; rel=\"noacl\""));
+        final Map<String, List<String>> headerMap = Map.of(HttpConstants.HEADER_LINK,
+                List.of("<" + aclUrl + ">; rel=\"noacl\""));
         final HttpHeaders headers = HttpHeaders.of(headerMap, (k, v) -> true);
         when(solidClient.createResource(testUrl, "hello", HttpConstants.MEDIA_TYPE_TEXT_PLAIN)).thenReturn(headers);
         when(solidClient.getResourceAclLink(testUrl)).thenReturn(null);
@@ -189,7 +191,8 @@ class SolidResourceTest {
 
     @Test
     void setAclMissing() throws Exception {
-        final Map<String, List<String>> headerMap = Map.of("Link", List.of("<" + aclUrl.toString() + ">; rel=\"acl\""));
+        final Map<String, List<String>> headerMap = Map.of(HttpConstants.HEADER_LINK,
+                List.of("<" + aclUrl.toString() + ">; rel=\"acl\""));
         final HttpHeaders headers = HttpHeaders.of(headerMap, (k, v) -> true);
         when(solidClient.createResource(testUrl, "hello", HttpConstants.MEDIA_TYPE_TEXT_PLAIN)).thenReturn(headers);
         when(solidClient.getAclLink(headers)).thenReturn(null);
@@ -204,7 +207,8 @@ class SolidResourceTest {
 
     @Test
     void setAcl() throws Exception {
-        final Map<String, List<String>> headerMap = Map.of("Link", List.of("<" + aclUrl.toString() + ">; rel=\"acl\""));
+        final Map<String, List<String>> headerMap = Map.of(HttpConstants.HEADER_LINK,
+                List.of("<" + aclUrl.toString() + ">; rel=\"acl\""));
         final HttpHeaders headers = HttpHeaders.of(headerMap, (k, v) -> true);
         when(solidClient.createResource(testUrl, "hello", HttpConstants.MEDIA_TYPE_TEXT_PLAIN)).thenReturn(headers);
         when(solidClient.getAclLink(headers)).thenReturn(aclUrl);
@@ -239,7 +243,8 @@ class SolidResourceTest {
 
     @Test
     void getAclUrlMissing() throws Exception {
-        final Map<String, List<String>> headerMap = Map.of("Link", List.of("<" + aclUrl.toString() + ">; rel=\"acl\""));
+        final Map<String, List<String>> headerMap = Map.of(HttpConstants.HEADER_LINK,
+                List.of("<" + aclUrl.toString() + ">; rel=\"acl\""));
         final HttpHeaders headers = HttpHeaders.of(headerMap, (k, v) -> true);
         when(solidClient.createResource(testUrl, "hello", HttpConstants.MEDIA_TYPE_TEXT_PLAIN)).thenReturn(headers);
         when(solidClient.getAclLink(headers)).thenReturn(null);

--- a/src/test/java/org/solid/testharness/utils/TestUtils.java
+++ b/src/test/java/org/solid/testharness/utils/TestUtils.java
@@ -3,7 +3,10 @@ package org.solid.testharness.utils;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
+import java.net.http.HttpResponse;
 import java.nio.file.Path;
+
+import static org.mockito.Mockito.*;
 
 public final class TestUtils {
     public static URL getFileUrl(final String file) throws MalformedURLException {
@@ -16,6 +19,12 @@ public final class TestUtils {
             uri = uri.substring(0, uri.length() - 1);
         }
         return URI.create(uri);
+    }
+
+    public static HttpResponse<Void> mockVoidResponse(final int status) {
+        final HttpResponse<Void> mockResponse = mock(HttpResponse.class);
+        when(mockResponse.statusCode()).thenReturn(status);
+        return mockResponse;
     }
 
     private TestUtils() { }

--- a/src/test/resources/assertor-testing-feature.ttl
+++ b/src/test/resources/assertor-testing-feature.ttl
@@ -1,0 +1,18 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix doap: <http://usefulinc.com/ns/doap#> .
+@prefix earl: <http://www.w3.org/ns/earl#> .
+@prefix ex: <https://example.org/> .
+
+ex:tester1 a earl:Software ;
+   doap:name "TESTER1"@en ;
+   doap:description "DESCRIPTION"@en ;
+   doap:created "2021-01-01"^^xsd:date ;
+   doap:developer <https://example.org/profile/card/#us>;
+   doap:homepage <https://example.org/tester> ;
+   doap:release [
+                    doap:revision "0.0.1-SNAPSHOT"
+                ] .
+
+ex:tester2 a earl:Software.


### PR DESCRIPTION
Lots of files changed but the core aspects are:
* Config - moved UserCredentials into this to make it easier to mock for testing AuthManager
* AuthManager - removed UserCredentials and added more error handling/exceptions
* Client - add null checks and refactor a bit for easier testing
* Other classes - minor changes e.g. method names

The rest are test files:
* http package - most work was here on using WireMock to test AuthManager and Client
* Using HttpConstants instead of bare strings
* Adding a few missing tests