### PR TITLE
Setup and tear down test container in TestSubject

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,6 @@ Karate based setup feature:
 * creates Authorization headers with these tokens
 * creates any test resources required for the test
 * adds ACLs if needed
-* provides a link to the container created for the test to be used in teardown
 
 Javascript function setup (see wac-allow tests):
 * the setup feature contains a function used to set up the clients and a test resource - this is shared across all
@@ -326,7 +325,6 @@ Javascript function setup (see wac-allow tests):
 The test files themselves:
 * run a background task for each scenario to call the necessary setup procedure
 * hold the returned test context to provide access to the Authorization headers and the test container or resource paths
-* prepare the teardown function that will delete the resources created for the tests
 * provide a set of scenarios that make http requests against the test resource and validate the responses
 
 ### Tips

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -3,6 +3,7 @@ configFile: config/config.ttl
 testSuiteDescription: example/example.ttl
 target: https://github.com/solid/conformance-test-harness/ess-compat
 #target: https://github.com/solid/conformance-test-harness/css
+#target: https://github.com/solid/conformance-test-harness/nss
 
 # mapping feature URIs
 feature:

--- a/example/content-negotiation/content-negotiation-jsonld.feature
+++ b/example/content-negotiation/content-negotiation-jsonld.feature
@@ -1,15 +1,13 @@
 Feature: Requests support content negotiation for JSON-LD resource
 
   Background: Create a JSON-LD resource
-    * def testContainer = createTestContainer(clients.alice)
+    * def testContainer = createTestContainer()
     * def exampleJson = karate.readAsString('../fixtures/example.json')
     * def resource = testContainer.createChildResource('.json', exampleJson, 'application/ld+json');
     * assert resource.exists()
     * def expected = RDFUtils.jsonLdToTripleArray(exampleJson, resource.getUrl())
     * configure headers = clients.alice.getAuthHeaders('GET', resource.getUrl())
     * url resource.getUrl()
-
-    * configure afterFeature = function() {resource.getContainer().delete()}
 
   Scenario: Alice can read the JSON-LD example as JSON-LD
     Given header Accept = 'application/ld+json'

--- a/example/content-negotiation/content-negotiation-turtle.feature
+++ b/example/content-negotiation/content-negotiation-turtle.feature
@@ -1,15 +1,13 @@
 Feature: Requests support content negotiation for Turtle resource
 
   Background: Create a turtle resource
-    * def testContainer = createTestContainer(clients.alice)
+    * def testContainer = createTestContainer()
     * def exampleTurtle = karate.readAsString('../fixtures/example.ttl')
     * def resource = testContainer.createChildResource('.ttl', exampleTurtle, 'text/turtle');
     * assert resource.exists()
     * def expected = RDFUtils.turtleToTripleArray(exampleTurtle, resource.getUrl())
     * configure headers = clients.alice.getAuthHeaders('GET', resource.getUrl())
     * url resource.getUrl()
-
-    * configure afterFeature = function() {resource.getContainer().delete()}
 
   Scenario: Alice can read the TTL example as JSON-LD
     Given header Accept = 'application/ld+json'

--- a/example/protected-operation/not-read-resource-access-AWC.feature
+++ b/example/protected-operation/not-read-resource-access-AWC.feature
@@ -5,8 +5,6 @@ Feature: Bob cannot read an RDF resource to which he is not granted read access
     * def resourceUrl = resource.getUrl()
     * url resourceUrl
 
-    * configure afterFeature = function() {resource.getContainer().delete()}
-
   Scenario: Bob can get the resource OPTIONS
     Given configure headers = clients.bob.getAuthHeaders('OPTIONS', resourceUrl)
     When method OPTIONS

--- a/example/protected-operation/not-read-resource-default-AWC.feature
+++ b/example/protected-operation/not-read-resource-default-AWC.feature
@@ -5,8 +5,6 @@ Feature: Bob cannot read an RDF resource to which he is not granted default read
     * def resourceUrl = resource.getUrl()
     * url resourceUrl
 
-    * configure afterFeature = function() {resource.getContainer().delete()}
-
   Scenario: Bob can get the resource OPTIONS
     Given configure headers = clients.bob.getAuthHeaders('OPTIONS', resourceUrl)
     When method OPTIONS

--- a/example/protected-operation/read-resource-access-R.feature
+++ b/example/protected-operation/read-resource-access-R.feature
@@ -5,8 +5,6 @@ Feature: Bob can only read an RDF resource to which he is only granted read acce
     * def resourceUrl = resource.getUrl()
     * url resourceUrl
 
-    * configure afterFeature = function() {resource.getContainer().delete()}
-
   Scenario: Bob can read the resource with GET
     Given configure headers = clients.bob.getAuthHeaders('GET', resourceUrl)
     When method GET

--- a/example/protected-operation/read-resource-default-R.feature
+++ b/example/protected-operation/read-resource-default-R.feature
@@ -5,8 +5,6 @@ Feature: Bob can only read an RDF resource to which he is only granted default r
     * def resourceUrl = resource.getUrl()
     * url resourceUrl
 
-    * configure afterFeature = function() {resource.getContainer().delete()}
-
   Scenario: Bob can read the resource with GET
     Given configure headers = clients.bob.getAuthHeaders('GET', resourceUrl)
     When method GET

--- a/example/protected-operation/setup.feature
+++ b/example/protected-operation/setup.feature
@@ -3,7 +3,7 @@ Feature: Set up a sample turtle file for Alice with defined access set for Bob
 
   @name=setupAccessTo # input: { bobAccessModes }
   Scenario: Create resource with access for Bob
-    * def testContainer = createTestContainer(clients.alice)
+    * def testContainer = createTestContainer()
     * def resource = testContainer.createChildResource('.ttl', karate.readAsString('../fixtures/example.ttl'), 'text/turtle');
     * assert resource.exists()
     * def acl =
@@ -16,7 +16,7 @@ Feature: Set up a sample turtle file for Alice with defined access set for Bob
 
   @name=setupDefault # input: { bobAccessModes }
   Scenario: Create resource with default access for Bob
-    * def testContainer = createTestContainer(clients.alice)
+    * def testContainer = createTestContainer()
     * def resource = testContainer.createChildResource('.ttl', karate.readAsString('../fixtures/example.ttl'), 'text/turtle');
     * assert resource.exists()
     * def acl =

--- a/example/wac-allow/access-Bob-W-public-RA.feature
+++ b/example/wac-allow/access-Bob-W-public-RA.feature
@@ -4,7 +4,7 @@ Feature: The WAC-Allow header shows user and public access modes with Bob write 
     * def setup =
     """
       function() {
-        const testContainer = createTestContainer(clients.alice);
+        const testContainer = createTestContainer();
         const resource = testContainer.createChildResource('.ttl', karate.readAsString('../fixtures/example.ttl'), 'text/turtle');
         if (resource.exists()) {
           const acl = aclPrefix
@@ -20,8 +20,6 @@ Feature: The WAC-Allow header shows user and public access modes with Bob write 
     * assert resource.exists()
     * def resourceUrl = resource.getUrl()
     * url resourceUrl
-
-    * configure afterFeature = function() {resource.getContainer().delete()}
 
   Scenario: There is an acl on the resource containing #bobAccessTo
     Given url resource.getAclUrl()

--- a/example/wac-allow/access-public-R.feature
+++ b/example/wac-allow/access-public-R.feature
@@ -4,7 +4,7 @@ Feature: The WAC-Allow header shows user and public access modes with public rea
     * def setup =
     """
       function() {
-        const testContainer = createTestContainer(clients.alice);
+        const testContainer = createTestContainer();
         const resource = testContainer.createChildResource('.ttl', karate.readAsString('../fixtures/example.ttl'), 'text/turtle');
         if (resource.exists()) {
           const acl = aclPrefix
@@ -19,8 +19,6 @@ Feature: The WAC-Allow header shows user and public access modes with public rea
     * assert resource.exists()
     * def resourceUrl = resource.getUrl()
     * url resourceUrl
-
-    * configure afterFeature = function() {resource.getContainer().delete()}
 
   Scenario: There is an acl on the resource containing #publicAccessTo
     Given url resource.getAclUrl()

--- a/example/wac-allow/default-Bob-W-public-RA.feature
+++ b/example/wac-allow/default-Bob-W-public-RA.feature
@@ -4,7 +4,7 @@ Feature: The WAC-Allow header shows user and public access modes with Bob write 
     * def setup =
     """
       function() {
-        const testContainer = createTestContainer(clients.alice);
+        const testContainer = createTestContainer();
         const resource = testContainer.createChildResource('.ttl', karate.readAsString('../fixtures/example.ttl'), 'text/turtle');
         if (resource.exists()) {
           const acl = aclPrefix
@@ -20,8 +20,6 @@ Feature: The WAC-Allow header shows user and public access modes with Bob write 
     * assert resource.exists()
     * def resourceUrl = resource.getUrl()
     * url resourceUrl
-
-    * configure afterFeature = function() {resource.getContainer().delete()}
 
   Scenario: There is no acl on the resource
     Given url resource.getAclUrl()

--- a/example/writing-resource/containment.feature
+++ b/example/writing-resource/containment.feature
@@ -1,12 +1,9 @@
 Feature: Creating a resource using PUT and PATCH must create intermediate containers
 
   Background: Set up clients and paths
-    * def testContainer = createTestContainer(clients.alice)
+    * def testContainer = createTestContainer()
     * def intermediateContainer = testContainer.generateChildContainer()
     * def resource = intermediateContainer.generateChildResource('.txt')
-
-    # prepare the teardown function
-    * configure afterScenario = function() {testContainer.delete()}
 
   Scenario: PUT creates a grandchild resource and intermediate containers
     * def resourceUrl = resource.getUrl()

--- a/src/main/java/org/solid/testharness/ConformanceTestHarness.java
+++ b/src/main/java/org/solid/testharness/ConformanceTestHarness.java
@@ -161,6 +161,7 @@ public class ConformanceTestHarness {
         logger.info("===================== RUN TESTS ========================");
         final TestSuiteResults results = testRunner.runTests(featurePaths,
                 testSubject.getTargetServer().getMaxThreads());
+        testSubject.tearDownServer();
 
         logger.info("===================== BUILD REPORTS ========================");
         final File outputDir = config.getOutputDirectory();

--- a/src/main/java/org/solid/testharness/utils/SolidContainer.java
+++ b/src/main/java/org/solid/testharness/utils/SolidContainer.java
@@ -76,4 +76,7 @@ public class SolidContainer extends SolidResource {
         return null;
     }
 
+    public void deleteContents() throws Exception {
+        solidClient.deleteContentsRecursively(url);
+    }
 }

--- a/src/main/resources/karate-base.js
+++ b/src/main/resources/karate-base.js
@@ -19,7 +19,7 @@ function fn() {
     const additionalConfig = karate.call('classpath:setup.js')
     return {
         target,
-        rootTestContainer: testSubject.getTestContainer(),
+        rootTestContainer: testSubject.getRootTestContainer(),
         ...additionalConfig,
         clients: karate.toMap(testSubject.clients),
         webIds: testSubject.webIds

--- a/src/main/resources/setup.js
+++ b/src/main/resources/setup.js
@@ -7,7 +7,7 @@ function() {
         SolidResource,
         SolidContainer,
         parseWacAllowHeader: (headers) => Java.type('org.solid.testharness.http.HttpUtils').parseWacAllowHeader(headers),
-        createTestContainer: (client) => SolidContainer.create(client, rootTestContainer).generateChildContainer(),
+        createTestContainer: () => rootTestContainer.generateChildContainer(),
         createOwnerAuthorization: (ownerAgent, targetUri) => `
 <#owner> a acl:Authorization;
   acl:agent <${ownerAgent}>;

--- a/src/test/java/TestScenarioRunner.java
+++ b/src/test/java/TestScenarioRunner.java
@@ -52,6 +52,7 @@ public class TestScenarioRunner {
 //        final String featurePath = "example/writing-resource/containment.feature";
         final String uri = Path.of(featurePath).toAbsolutePath().normalize().toUri().toString();
         final TestSuiteResults results = testRunner.runTest(uri);
+        testSubject.tearDownServer();
         assertNotNull(results);
         assertEquals(0, results.getFailCount(), results.getErrorMessages());
     }

--- a/src/test/java/org/solid/testharness/http/SolidClientTest.java
+++ b/src/test/java/org/solid/testharness/http/SolidClientTest.java
@@ -223,7 +223,7 @@ class SolidClientTest {
         when(mockClient.head(any())).thenReturn(mockResponse);
         when(mockClient.put(eq(resourceAcl), eq("ACL"), eq(HttpConstants.MEDIA_TYPE_TEXT_TURTLE)))
                 .thenReturn(mockResponse);
-        when(mockResponse.statusCode()).thenReturn(500);
+        when(mockResponse.statusCode()).thenReturn(400);
 
         final SolidClient solidClient = new SolidClient(mockClient);
         final boolean res = solidClient.createAcl(resourceAcl, "ACL");
@@ -248,13 +248,13 @@ class SolidClientTest {
     void getContainmentDataFails() throws IOException, InterruptedException {
         final Client mockClient = mock(Client.class);
         final URI resourceAcl = URI.create("http://localhost:3000/test");
-        final HttpResponse<String> mockResponse = TestUtils.mockStringResponse(500, null);
+        final HttpResponse<String> mockResponse = TestUtils.mockStringResponse(400, null);
 
         when(mockClient.getAsTurtle(eq(resourceAcl))).thenReturn(mockResponse);
 
         final SolidClient solidClient = new SolidClient(mockClient);
         final Exception exception = assertThrows(Exception.class, () -> solidClient.getContainmentData(resourceAcl));
-        assertEquals("Error response=500 trying to get container members for http://localhost:3000/test",
+        assertEquals("Error response=400 trying to get container members for http://localhost:3000/test",
                 exception.getMessage());
     }
 
@@ -289,7 +289,7 @@ class SolidClientTest {
         final String data = PREFIX + "<http://localhost:3000/> ldp:contains <http://localhost:3000/test>.";
         final Client mockClient = mock(Client.class);
         final HttpResponse<String> mockResponse = TestUtils.mockStringResponse(200, data);
-        final HttpResponse<Void> mockResponseOk = TestUtils.mockVoidResponse(200);
+        final HttpResponse<Void> mockResponseOk = TestUtils.mockVoidResponse(204);
 
         when(mockClient.deleteAsync(URI.create("http://localhost:3000/test")))
                 .thenReturn(CompletableFuture.supplyAsync(() -> mockResponseOk));
@@ -306,7 +306,7 @@ class SolidClientTest {
                 "<http://localhost:3000/test>, <http://localhost:3000/test2>.";
         final Client mockClient = mock(Client.class);
         final HttpResponse<String> mockResponse = TestUtils.mockStringResponse(200, data);
-        final HttpResponse<Void> mockResponseOk = TestUtils.mockVoidResponse(200);
+        final HttpResponse<Void> mockResponseOk = TestUtils.mockVoidResponse(204);
 
         when(mockClient.getAsTurtle(eq(URI.create("http://localhost:3000/")))).thenReturn(mockResponse);
         when(mockClient.deleteAsync(URI.create("http://localhost:3000/test")))
@@ -328,8 +328,8 @@ class SolidClientTest {
                 "<http://localhost:3000/test>, <http://localhost:3000/test2>.";
         final Client mockClient = mock(Client.class);
         final HttpResponse<String> mockResponse = TestUtils.mockStringResponse(200, data);
-        final HttpResponse<Void> mockResponseOk = TestUtils.mockVoidResponse(200);
-        final HttpResponse<Void> mockResponseFail = TestUtils.mockVoidResponse(500);
+        final HttpResponse<Void> mockResponseOk = TestUtils.mockVoidResponse(204);
+        final HttpResponse<Void> mockResponseFail = TestUtils.mockVoidResponse(400);
 
         when(mockClient.getAsTurtle(eq(URI.create("http://localhost:3000/")))).thenReturn(mockResponse);
         when(mockClient.deleteAsync(URI.create("http://localhost:3000/test")))
@@ -351,7 +351,7 @@ class SolidClientTest {
                 "<http://localhost:3000/test>, <http://localhost:3000/test2>.";
         final Client mockClient = mock(Client.class);
         final HttpResponse<String> mockResponse = TestUtils.mockStringResponse(200, data);
-        final HttpResponse<Void> mockResponseOk = TestUtils.mockVoidResponse(200);
+        final HttpResponse<Void> mockResponseOk = TestUtils.mockVoidResponse(204);
         final HttpResponse<Void> mockResponseException = mock(HttpResponse.class);
         // TODO: This causes a failure in a delete but the code cannto detect which so carries on deleting other
         // resources which may fail. Better handling needed.
@@ -378,7 +378,7 @@ class SolidClientTest {
     void deleteContainerListFails() throws IOException, InterruptedException {
         final String data = PREFIX + "<http://localhost:3000/> ldp:contains <http://localhost:3000/test>.";
         final Client mockClient = mock(Client.class);
-        final HttpResponse<String> mockResponse = TestUtils.mockStringResponse(500, null);
+        final HttpResponse<String> mockResponse = TestUtils.mockStringResponse(400, null);
 
         when(mockClient.getAsTurtle(eq(URI.create("http://localhost:3000/")))).thenReturn(mockResponse);
 
@@ -394,7 +394,7 @@ class SolidClientTest {
                 "<http://localhost:3000/test>, <http://localhost:3000/test2>.";
         final Client mockClient = mock(Client.class);
         final HttpResponse<String> mockResponse = TestUtils.mockStringResponse(200, data);
-        final HttpResponse<Void> mockResponseOk = TestUtils.mockVoidResponse(200);
+        final HttpResponse<Void> mockResponseOk = TestUtils.mockVoidResponse(204);
 
         when(mockClient.getAsTurtle(eq(URI.create("http://localhost:3000/")))).thenReturn(mockResponse);
         when(mockClient.deleteAsync(URI.create("http://localhost:3000/test")))
@@ -422,7 +422,7 @@ class SolidClientTest {
         final Client mockClient = mock(Client.class);
         final HttpResponse<String> mockResponse = TestUtils.mockStringResponse(200, data);
         final HttpResponse<String> mockResponseChild = TestUtils.mockStringResponse(200, data2);
-        final HttpResponse<Void> mockResponseOk = TestUtils.mockVoidResponse(200);
+        final HttpResponse<Void> mockResponseOk = TestUtils.mockVoidResponse(204);
 
         when(mockClient.getAsTurtle(eq(URI.create("http://localhost:3000/")))).thenReturn(mockResponse);
         when(mockClient.getAsTurtle(eq(URI.create("http://localhost:3000/child/")))).thenReturn(mockResponseChild);

--- a/src/test/java/org/solid/testharness/http/SolidClientTest.java
+++ b/src/test/java/org/solid/testharness/http/SolidClientTest.java
@@ -26,6 +26,7 @@ package org.solid.testharness.http;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
 import org.solid.testharness.utils.TestHarnessInitializationException;
+import org.solid.testharness.utils.TestUtils;
 
 import javax.inject.Inject;
 import java.io.IOException;
@@ -234,7 +235,7 @@ class SolidClientTest {
     void getContainmentData() throws Exception {
         final Client mockClient = mock(Client.class);
         final URI resourceAcl = URI.create("http://localhost:3000/test");
-        final HttpResponse<String> mockResponse = mockStringResponse(200, "TEST");
+        final HttpResponse<String> mockResponse = TestUtils.mockStringResponse(200, "TEST");
 
         when(mockClient.getAsTurtle(eq(resourceAcl))).thenReturn(mockResponse);
 
@@ -247,7 +248,7 @@ class SolidClientTest {
     void getContainmentDataFails() throws IOException, InterruptedException {
         final Client mockClient = mock(Client.class);
         final URI resourceAcl = URI.create("http://localhost:3000/test");
-        final HttpResponse<String> mockResponse = mockStringResponse(500, null);
+        final HttpResponse<String> mockResponse = TestUtils.mockStringResponse(500, null);
 
         when(mockClient.getAsTurtle(eq(resourceAcl))).thenReturn(mockResponse);
 
@@ -287,8 +288,8 @@ class SolidClientTest {
     void deleteResource() {
         final String data = PREFIX + "<http://localhost:3000/> ldp:contains <http://localhost:3000/test>.";
         final Client mockClient = mock(Client.class);
-        final HttpResponse<String> mockResponse = mockStringResponse(200, data);
-        final HttpResponse<Void> mockResponseOk = mockVoidResponse(200);
+        final HttpResponse<String> mockResponse = TestUtils.mockStringResponse(200, data);
+        final HttpResponse<Void> mockResponseOk = TestUtils.mockVoidResponse(200);
 
         when(mockClient.deleteAsync(URI.create("http://localhost:3000/test")))
                 .thenReturn(CompletableFuture.supplyAsync(() -> mockResponseOk));
@@ -304,8 +305,8 @@ class SolidClientTest {
         final String data = PREFIX + "<http://localhost:3000/> ldp:contains " +
                 "<http://localhost:3000/test>, <http://localhost:3000/test2>.";
         final Client mockClient = mock(Client.class);
-        final HttpResponse<String> mockResponse = mockStringResponse(200, data);
-        final HttpResponse<Void> mockResponseOk = mockVoidResponse(200);
+        final HttpResponse<String> mockResponse = TestUtils.mockStringResponse(200, data);
+        final HttpResponse<Void> mockResponseOk = TestUtils.mockVoidResponse(200);
 
         when(mockClient.getAsTurtle(eq(URI.create("http://localhost:3000/")))).thenReturn(mockResponse);
         when(mockClient.deleteAsync(URI.create("http://localhost:3000/test")))
@@ -326,9 +327,9 @@ class SolidClientTest {
         final String data = PREFIX + "<http://localhost:3000/> ldp:contains " +
                 "<http://localhost:3000/test>, <http://localhost:3000/test2>.";
         final Client mockClient = mock(Client.class);
-        final HttpResponse<String> mockResponse = mockStringResponse(200, data);
-        final HttpResponse<Void> mockResponseOk = mockVoidResponse(200);
-        final HttpResponse<Void> mockResponseFail = mockVoidResponse(500);
+        final HttpResponse<String> mockResponse = TestUtils.mockStringResponse(200, data);
+        final HttpResponse<Void> mockResponseOk = TestUtils.mockVoidResponse(200);
+        final HttpResponse<Void> mockResponseFail = TestUtils.mockVoidResponse(500);
 
         when(mockClient.getAsTurtle(eq(URI.create("http://localhost:3000/")))).thenReturn(mockResponse);
         when(mockClient.deleteAsync(URI.create("http://localhost:3000/test")))
@@ -349,8 +350,8 @@ class SolidClientTest {
         final String data = PREFIX + "<http://localhost:3000/> ldp:contains " +
                 "<http://localhost:3000/test>, <http://localhost:3000/test2>.";
         final Client mockClient = mock(Client.class);
-        final HttpResponse<String> mockResponse = mockStringResponse(200, data);
-        final HttpResponse<Void> mockResponseOk = mockVoidResponse(200);
+        final HttpResponse<String> mockResponse = TestUtils.mockStringResponse(200, data);
+        final HttpResponse<Void> mockResponseOk = TestUtils.mockVoidResponse(200);
         final HttpResponse<Void> mockResponseException = mock(HttpResponse.class);
         // TODO: This causes a failure in a delete but the code cannto detect which so carries on deleting other
         // resources which may fail. Better handling needed.
@@ -377,7 +378,7 @@ class SolidClientTest {
     void deleteContainerListFails() throws IOException, InterruptedException {
         final String data = PREFIX + "<http://localhost:3000/> ldp:contains <http://localhost:3000/test>.";
         final Client mockClient = mock(Client.class);
-        final HttpResponse<String> mockResponse = mockStringResponse(500, null);
+        final HttpResponse<String> mockResponse = TestUtils.mockStringResponse(500, null);
 
         when(mockClient.getAsTurtle(eq(URI.create("http://localhost:3000/")))).thenReturn(mockResponse);
 
@@ -392,8 +393,8 @@ class SolidClientTest {
         final String data = PREFIX + "<http://localhost:3000/> ldp:contains " +
                 "<http://localhost:3000/test>, <http://localhost:3000/test2>.";
         final Client mockClient = mock(Client.class);
-        final HttpResponse<String> mockResponse = mockStringResponse(200, data);
-        final HttpResponse<Void> mockResponseOk = mockVoidResponse(200);
+        final HttpResponse<String> mockResponse = TestUtils.mockStringResponse(200, data);
+        final HttpResponse<Void> mockResponseOk = TestUtils.mockVoidResponse(200);
 
         when(mockClient.getAsTurtle(eq(URI.create("http://localhost:3000/")))).thenReturn(mockResponse);
         when(mockClient.deleteAsync(URI.create("http://localhost:3000/test")))
@@ -419,9 +420,9 @@ class SolidClientTest {
         final String data2 = PREFIX + "<http://localhost:3000/child/> ldp:contains " +
                 "<http://localhost:3000/test2>, <http://localhost:3000/test3>.";
         final Client mockClient = mock(Client.class);
-        final HttpResponse<String> mockResponse = mockStringResponse(200, data);
-        final HttpResponse<String> mockResponseChild = mockStringResponse(200, data2);
-        final HttpResponse<Void> mockResponseOk = mockVoidResponse(200);
+        final HttpResponse<String> mockResponse = TestUtils.mockStringResponse(200, data);
+        final HttpResponse<String> mockResponseChild = TestUtils.mockStringResponse(200, data2);
+        final HttpResponse<Void> mockResponseOk = TestUtils.mockVoidResponse(200);
 
         when(mockClient.getAsTurtle(eq(URI.create("http://localhost:3000/")))).thenReturn(mockResponse);
         when(mockClient.getAsTurtle(eq(URI.create("http://localhost:3000/child/")))).thenReturn(mockResponseChild);
@@ -452,19 +453,6 @@ class SolidClientTest {
     void deleteNull() {
         final SolidClient solidClient = new SolidClient();
         assertThrows(IllegalArgumentException.class, () -> solidClient.deleteResourceRecursively(null));
-    }
-
-    private HttpResponse<String> mockStringResponse(final int status, final String body) {
-        final HttpResponse<String> mockResponse = mock(HttpResponse.class);
-        when(mockResponse.statusCode()).thenReturn(status);
-        when(mockResponse.body()).thenReturn(body);
-        return mockResponse;
-    }
-
-    private HttpResponse<Void> mockVoidResponse(final int status) {
-        final HttpResponse<Void> mockResponse = mock(HttpResponse.class);
-        when(mockResponse.statusCode()).thenReturn(status);
-        return mockResponse;
     }
 
     @Test

--- a/src/test/java/org/solid/testharness/utils/SolidContainerTest.java
+++ b/src/test/java/org/solid/testharness/utils/SolidContainerTest.java
@@ -129,4 +129,11 @@ class SolidContainerTest {
         final SolidContainer container = SolidContainer.create(solidClient, testUrl.toString());
         assertNull(container.createChildResource(".suffix", "hello", null));
     }
+
+    @Test
+    void deleteContents() throws Exception {
+        final SolidContainer container = SolidContainer.create(solidClient, testUrl.toString());
+        assertDoesNotThrow(() -> container.deleteContents());
+        verify(solidClient).deleteContentsRecursively(testUrl);
+    }
 }

--- a/src/test/java/org/solid/testharness/utils/TestUtils.java
+++ b/src/test/java/org/solid/testharness/utils/TestUtils.java
@@ -50,5 +50,12 @@ public final class TestUtils {
         return mockResponse;
     }
 
+    public static HttpResponse<String> mockStringResponse(final int status, final String body) {
+        final HttpResponse<String> mockResponse = mock(HttpResponse.class);
+        when(mockResponse.statusCode()).thenReturn(status);
+        when(mockResponse.body()).thenReturn(body);
+        return mockResponse;
+    }
+
     private TestUtils() { }
 }


### PR DESCRIPTION
Instead of deleting the test containers at the end of each test, a root container is created for each run and the this is recursively deleted in a teardown function within the test harness. It avoids the need for test cases to have a tear down and ensure all files are cleaned up.
The code changes in src/main are minor and there are additional tests for this but all the example test cases needed to be changed.