### PR TITLE
Support reporting results for tests against multiple input specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,10 +250,11 @@ usage: run
     --subjects <arg> URL or path to test subject config (Turtle)
  -t,--target <arg>   target server
 ```
-If you want to control the logging output or set up mappings between URIs and local directories for test features you
-can also create `config/application.yaml` in your current working directory based on the definition shown above. Note
-that the jar file does not have to be in this directory. The command line options override any equivalent options set
-in any application properties file. An example of the properties that can be set via this file is:
+If you want to control the logging output or set up mappings between URIs and local directories for test features or 
+source documents, you can also create `config/application.yaml` in your current working directory based on the 
+definition shown above. Note that the jar file does not have to be in this directory. The command line options override
+any equivalent options set in any application properties file. An example of the properties that can be set via this
+file is:
 ```yaml
 subjects: config/config.ttl
 sources:

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -1,7 +1,8 @@
 # local override of properties
 subjects: config/config.ttl
 sources:
-  - example/example.ttl
+  - https://raw.githubusercontent.com/solid/conformance-test-harness/main/example/solid-protocol-spec.ttl
+  - https://raw.githubusercontent.com/solid/conformance-test-harness/main/example/web-access-control-spec.ttl
 target: https://github.com/solid/conformance-test-harness/ess-compat
 #target: https://github.com/solid/conformance-test-harness/ess
 #target: https://github.com/solid/conformance-test-harness/css
@@ -50,7 +51,7 @@ quarkus:
       - prefix: https://example.org/manifests
         path: src/test/resources/discovery
       - prefix: https://example.org/badmapping
-        path: http://example.org:-1/
+        path: https://example.org:-1/
 
   agent: AGENT
   connectTimeout: 1000

--- a/example/solid-protocol-spec.ttl
+++ b/example/solid-protocol-spec.ttl
@@ -34,14 +34,14 @@
   spec:normativeConformanceLevel spec:ConformanceMust ;
 .
 
-<https://solidproject.org/TR/protocol#test-server-header-put-content-type>
-  a spec:NormativeRequirement ;
-  spec:conformanceRole spec:ServerConformanceClass ;
-  spec:normativeConformanceLevel spec:ConformanceMust ;
-  spec:httpRequest [
-    http:mthd httpm:PUT
-  ];
-  spec:httpRequestHeader [
-    http:hdrName httph:content-type
-  ];
-.
+#<https://solidproject.org/TR/protocol#test-server-header-put-content-type>
+#  a spec:NormativeRequirement ;
+#  spec:conformanceRole spec:ServerConformanceClass ;
+#  spec:normativeConformanceLevel spec:ConformanceMust ;
+#  spec:httpRequest [
+#    http:mthd httpm:PUT
+#  ];
+#  spec:httpRequestHeader [
+#    http:hdrName httph:content-type
+#  ];
+#.

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <rdf4j.version>3.7.0</rdf4j.version>
         <semargl.version>0.7</semargl.version>
         <jakarta.version>3.0.0</jakarta.version>
-        <jose4j.version>0.7.7</jose4j.version>
+        <jose4j.version>0.7.8</jose4j.version>
         <commons.text.version>1.9</commons.text.version>
         <commons.lang.version>3.12.0</commons.lang.version>
         <commons.cli.version>1.4</commons.cli.version>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <license.plugin.version>4.1</license.plugin.version>
 
         <!-- dependencies -->
-        <quarkus.version>1.13.6.Final</quarkus.version>
+        <quarkus.version>1.13.7.Final</quarkus.version>
         <karate.version>1.0.1</karate.version>
         <junit.jupiter.version>5.7.2</junit.jupiter.version>
         <hamcrest.version>2.2</hamcrest.version>

--- a/src/main/java/org/solid/testharness/ConformanceTestHarness.java
+++ b/src/main/java/org/solid/testharness/ConformanceTestHarness.java
@@ -27,12 +27,12 @@ import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.util.ModelBuilder;
 import org.eclipse.rdf4j.model.util.Values;
-import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.solid.common.vocab.DOAP;
 import org.solid.common.vocab.EARL;
+import org.solid.common.vocab.RDF;
 import org.solid.testharness.config.Config;
 import org.solid.testharness.config.TestSubject;
 import org.solid.testharness.discovery.TestSuiteDescription;
@@ -85,7 +85,7 @@ public class ConformanceTestHarness {
                 final ModelBuilder builder = new ModelBuilder();
                 final BNode bnode = Values.bnode();
                 conn.add(builder.subject(assertor)
-                        .add(RDF.TYPE, EARL.Software)
+                        .add(RDF.type, EARL.Software)
                         .add(DOAP.name, properties.getProperty("package.name"))
                         .add(DOAP.description, properties.getProperty("package.description"))
                         .add(DOAP.created, Date.from(

--- a/src/main/java/org/solid/testharness/config/PathMappings.java
+++ b/src/main/java/org/solid/testharness/config/PathMappings.java
@@ -91,7 +91,8 @@ public class PathMappings {
     private URL toUrl(final String location) {
         final Mapping mapping = mappings.stream().filter(m -> location.startsWith(m.prefix)).findFirst().orElse(null);
         try {
-            return new URL(mapping != null ? location.replace(mapping.prefix, mapping.path) : location);
+            return new URL(
+                    mapping != null ? location.replace(mapping.prefix, mapping.path) : location);
         } catch (MalformedURLException e) {
             throw (TestHarnessInitializationException) new TestHarnessInitializationException("Bad URL mapping: %s",
                     e.toString()).initCause(e);

--- a/src/main/java/org/solid/testharness/reporting/ReportGenerator.java
+++ b/src/main/java/org/solid/testharness/reporting/ReportGenerator.java
@@ -26,10 +26,11 @@ package org.solid.testharness.reporting;
 import io.quarkus.qute.Location;
 import io.quarkus.qute.Template;
 import org.eclipse.rdf4j.model.IRI;
-import org.eclipse.rdf4j.query.TupleQuery;
+import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.solid.common.vocab.RDF;
 import org.solid.common.vocab.SPEC;
 import org.solid.testharness.utils.DataRepository;
 
@@ -75,9 +76,10 @@ public class ReportGenerator {
 
     private List<IRI> getSpecifications() {
         try (RepositoryConnection conn = dataRepository.getConnection()) {
-            final String queryString = "SELECT ?spec WHERE {?spec a <" + SPEC.Specification.stringValue() + ">}";
-            final TupleQuery tupleQuery = conn.prepareTupleQuery(queryString);
-            return tupleQuery.evaluate().stream().map(bs -> (IRI) bs.getValue("spec")).collect(Collectors.toList());
+            return conn.getStatements(null, RDF.type, SPEC.Specification).stream()
+                    .map(Statement::getSubject)
+                    .map(IRI.class::cast)
+                    .collect(Collectors.toList());
         }
     }
 }

--- a/src/main/java/org/solid/testharness/reporting/ResultData.java
+++ b/src/main/java/org/solid/testharness/reporting/ResultData.java
@@ -26,32 +26,29 @@ package org.solid.testharness.reporting;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
 import org.solid.common.vocab.*;
-import org.solid.testharness.utils.DataModelBase;
 import org.solid.testharness.utils.Namespaces;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.eclipse.rdf4j.model.util.Values.iri;
 
-public class ResultData extends DataModelBase {
+public class ResultData {
     private Assertor assertor;
+    private List<Specification> specifications;
 
-    public ResultData(final IRI subject) {
-        super(subject);
+    public ResultData(final List<IRI> specifications) {
         assertor = new Assertor(iri(Namespaces.TEST_HARNESS_URI));
+        this.specifications = specifications.stream().map(Specification::new).collect(Collectors.toList());
     }
 
     public String getPrefixes() {
         return Namespaces.generateHtmlPrefixes(List.of(RDF.PREFIX, RDFS.PREFIX, XSD.PREFIX, DCTERMS.PREFIX, DOAP.PREFIX,
-                SOLID.PREFIX, SOLID_TEST.PREFIX, EARL.PREFIX, TD.PREFIX));
+                SOLID.PREFIX, SOLID_TEST.PREFIX, EARL.PREFIX, TD.PREFIX, SPEC.PREFIX));
     }
 
-    public List<SpecificationTestCase> getSpecificationTestCases() {
-        return getModelList(DCTERMS.hasPart, SpecificationTestCase.class);
-    }
-
-    public String getSpecification() {
-        return getIriAsString(DOAP.implements_);
+    public List<Specification> getSpecifications() {
+        return specifications;
     }
 
     public Assertor getAssertor() {

--- a/src/main/java/org/solid/testharness/reporting/Scenario.java
+++ b/src/main/java/org/solid/testharness/reporting/Scenario.java
@@ -32,7 +32,7 @@ import java.util.List;
 
 public class Scenario extends DataModelBase {
     public Scenario(final IRI subject) {
-        super(subject, ConstructMode.LIST);
+        super(subject, ConstructMode.DEEP_WITH_LISTS);
     }
 
     public String getTitle() {

--- a/src/main/java/org/solid/testharness/reporting/Specification.java
+++ b/src/main/java/org/solid/testharness/reporting/Specification.java
@@ -24,30 +24,22 @@
 package org.solid.testharness.reporting;
 
 import org.eclipse.rdf4j.model.IRI;
-import org.solid.common.vocab.DCTERMS;
-import org.solid.common.vocab.TD;
+import org.solid.common.vocab.RDFS;
+import org.solid.common.vocab.SPEC;
 import org.solid.testharness.utils.DataModelBase;
 
 import java.util.List;
 
-public class SpecificationTestCase extends DataModelBase {
-    public SpecificationTestCase(final IRI subject) {
+public class Specification extends DataModelBase {
+    public Specification(final IRI subject) {
         super(subject);
     }
 
-    public String getTitle() {
-        return getLiteralAsString(DCTERMS.title);
+    public String getManifest() {
+        return getIriAsString(RDFS.seeAlso);
     }
 
-    public String getDescription() {
-        return getLiteralAsString(DCTERMS.description);
-    }
-
-    public String getSpecificationReference() {
-        return getIriAsString(TD.specificationReference);
-    }
-
-    public List<TestCase> getTestCases() {
-        return getModelList(DCTERMS.hasPart, TestCase.class);
+    public List<SpecificationRequirement> getSpecificationRequirements() {
+        return getModelList(SPEC.requirement, SpecificationRequirement.class);
     }
 }

--- a/src/main/java/org/solid/testharness/reporting/SpecificationRequirement.java
+++ b/src/main/java/org/solid/testharness/reporting/SpecificationRequirement.java
@@ -32,7 +32,7 @@ import java.util.List;
 
 public class SpecificationRequirement extends DataModelBase {
     public SpecificationRequirement(final IRI subject) {
-        super(subject, ConstructMode.INC_PARENTS);
+        super(subject, ConstructMode.INC_REFS);
     }
 
     public String getConformanceRole() {

--- a/src/main/java/org/solid/testharness/reporting/SpecificationRequirement.java
+++ b/src/main/java/org/solid/testharness/reporting/SpecificationRequirement.java
@@ -24,30 +24,33 @@
 package org.solid.testharness.reporting;
 
 import org.eclipse.rdf4j.model.IRI;
-import org.solid.common.vocab.DCTERMS;
+import org.solid.common.vocab.SPEC;
 import org.solid.common.vocab.TD;
 import org.solid.testharness.utils.DataModelBase;
 
 import java.util.List;
 
-public class SpecificationTestCase extends DataModelBase {
-    public SpecificationTestCase(final IRI subject) {
-        super(subject);
+public class SpecificationRequirement extends DataModelBase {
+    public SpecificationRequirement(final IRI subject) {
+        super(subject, ConstructMode.INC_PARENTS);
     }
 
-    public String getTitle() {
-        return getLiteralAsString(DCTERMS.title);
+    public String getConformanceRole() {
+        return getIriAsString(SPEC.conformanceRole);
     }
 
-    public String getDescription() {
-        return getLiteralAsString(DCTERMS.description);
+    public String getConformanceLevel() {
+        return getIriAsString(SPEC.normativeConformanceLevel);
     }
 
-    public String getSpecificationReference() {
-        return getIriAsString(TD.specificationReference);
-    }
-
-    public List<TestCase> getTestCases() {
-        return getModelList(DCTERMS.hasPart, TestCase.class);
+    public SpecificationTestCase getSpecificationTestCase() {
+        final List<SpecificationTestCase> specificationTestCases = getModelListByObject(TD.specificationReference,
+                SpecificationTestCase.class);
+        if (specificationTestCases != null) {
+            return specificationTestCases.get(0);
+        } else {
+            return null;
+        }
     }
 }
+

--- a/src/main/java/org/solid/testharness/utils/DataRepository.java
+++ b/src/main/java/org/solid/testharness/utils/DataRepository.java
@@ -31,7 +31,6 @@ import org.eclipse.rdf4j.model.*;
 import org.eclipse.rdf4j.model.impl.LinkedHashModel;
 import org.eclipse.rdf4j.model.util.ModelBuilder;
 import org.eclipse.rdf4j.model.util.RDFCollections;
-import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.RepositoryException;
@@ -43,6 +42,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.solid.common.vocab.DCTERMS;
 import org.solid.common.vocab.EARL;
+import org.solid.common.vocab.RDF;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
@@ -119,17 +119,17 @@ public class DataRepository implements Repository {
             final IRI featureAssertion = createSkolemizedBlankNode(featureIri);
             final IRI featureResult = createSkolemizedBlankNode(featureIri);
             conn.add(builder.subject(featureIri)
-                    .add(RDF.TYPE, EARL.TestCriterion)
-                    .add(RDF.TYPE, EARL.TestFeature)
+                    .add(RDF.type, EARL.TestCriterion)
+                    .add(RDF.type, EARL.TestFeature)
                     .add(DCTERMS.title, fr.getFeature().getName())
                     .add(EARL.assertions, featureAssertion)
-                    .add(featureAssertion, RDF.TYPE, EARL.Assertion)
+                    .add(featureAssertion, RDF.type, EARL.Assertion)
                     .add(featureAssertion, EARL.assertedBy, assertor)
                     .add(featureAssertion, EARL.test, featureIri)
                     .add(featureAssertion, EARL.subject, testSubject)
                     .add(featureAssertion, EARL.mode, EARL.automatic)
                     .add(featureAssertion, EARL.result, featureResult)
-                    .add(featureResult, RDF.TYPE, EARL.TestResult)
+                    .add(featureResult, RDF.type, EARL.TestResult)
                     .add(featureResult, EARL.outcome, fr.isFailed() ? EARL.failed : EARL.passed)
                     .add(featureResult, DCTERMS.date, new Date((long) (startTime + fr.getDurationMillis())))
                     .build());
@@ -139,18 +139,18 @@ public class DataRepository implements Repository {
                 final IRI scenarioResult = createSkolemizedBlankNode(featureIri);
                 builder = new ModelBuilder();
                 conn.add(builder.subject(scenarioIri)
-                        .add(RDF.TYPE, EARL.TestCriterion)
-                        .add(RDF.TYPE, EARL.TestCase)
+                        .add(RDF.type, EARL.TestCriterion)
+                        .add(RDF.type, EARL.TestCase)
                         .add(DCTERMS.title, sr.getScenario().getName())
                         .add(DCTERMS.isPartOf, featureIri)
                         .add(EARL.assertions, scenarioAssertion)
-                        .add(scenarioAssertion, RDF.TYPE, EARL.Assertion)
+                        .add(scenarioAssertion, RDF.type, EARL.Assertion)
                         .add(scenarioAssertion, EARL.assertedBy, assertor)
                         .add(scenarioAssertion, EARL.test, scenarioIri)
                         .add(scenarioAssertion, EARL.subject, testSubject)
                         .add(scenarioAssertion, EARL.mode, EARL.automatic)
                         .add(scenarioAssertion, EARL.result, scenarioResult)
-                        .add(scenarioResult, RDF.TYPE, EARL.TestResult)
+                        .add(scenarioResult, RDF.type, EARL.TestResult)
                         .add(scenarioResult, EARL.outcome, sr.isFailed() ? EARL.failed : EARL.passed)
                         .add(scenarioResult, DCTERMS.date, new Date((long) (startTime + sr.getDurationMillis())))
                         .add(featureIri, DCTERMS.hasPart, scenarioIri)
@@ -160,7 +160,7 @@ public class DataRepository implements Repository {
                         final IRI step = createSkolemizedBlankNode(featureIri);
                         final ModelBuilder stepBuilder = new ModelBuilder();
                         stepBuilder.subject(step)
-                                .add(RDF.TYPE, EARL.TestStep)
+                                .add(RDF.type, EARL.TestStep)
                                 .add(DCTERMS.title, str.getStep().getPrefix() + " " + str.getStep().getText())
                                 .add(EARL.outcome, EARL_RESULT.get(str.getResult().getStatus()));
                         if (!str.getStepLog().isEmpty()) {

--- a/src/main/resources/templates/coverage-report.html
+++ b/src/main/resources/templates/coverage-report.html
@@ -14,36 +14,48 @@
 <body about="{subject}" prefix="{prefixes}">
 <header>
     <h1>Solid Specification - Conformance Test Suite Coverage Report</h1>
-    <h2>
-        <dl><dt>Specification under test</dt><dd><a href="{specification}" rel="doap:implements" title="Specification link">{specification}</a></dd></dl>
-    </h2>
-    {#with assertor}{#include assertor /}{/with}
+    {#include specification-header /}
 </header>
 
 <main>
-    {#if specificationTestCases}
-    {#each specificationTestCases}
-    <div property="dcterms:hasPart" resource="{it.subject}">
-        <section about="{it.subject}" typeof="{it.typesList}">
-            <h3 property="dcterms:title">{it.title}</h3>
-            <p property="dcterms:description">{it.description}</p>
-            <table>
-                <tr>
-                    <th>TestCase</th>
-                    <th>Title</th>
-                    <th>Level</th>
-                    <th>Status</th>
-                    <th>Implemented</th>
-                </tr>
-                {#each it.testCases}
-                    {#include testcase coverageMode=true /}
-                {/each}
-            </table>
-        </section>
-    </div>
+    {#if specifications}
+    {#each specifications}
+    <section about="{it.subject}" typeof="{it.typesList}">
+        <h2>Specification: {it.subject}</h2>
+        {#if it.specificationRequirements}
+        {#each it.specificationRequirements}
+        <div about="{it.subject}" rel="spec:requirement" typeof="{it.typesList}">
+            <dl><dt>Conformance Role</dt><dd>{it.conformanceRole}</dd></dl>
+            <dl><dt>Conformance Level</dt><dd>{it.conformanceLevel}</dd></dl>
+            {#with it.specificationTestCase}
+            <div about="{subject}" rev="td:specificationReference" resource="{it.subject}" typeof="{it.typesList}">
+                <h3 property="dcterms:title">{title}</h3>
+                <p property="dcterms:description">{description}</p>
+                {#if testCases}
+                <table>
+                    <tr>
+                        <th>TestCase</th>
+                        <th>Title</th>
+                        <th>Level</th>
+                        <th>Status</th>
+                        <th>Implemented</th>
+                    </tr>
+                    {#each testCases}
+                        {#include testcase coverageMode=true /}
+                    {/each}
+                </table>
+                {#else}
+                <p>No test cases found</p>
+                {/if}
+            </div>
+            {/with}
+        </div>
+        {/each}
+        {#else}
+        <p>No tests were discovered.</p>
+        {/if}
+    </section>
     {/each}
-    {#else}
-    <p>No tests were discovered.</p>
     {/if}
 </main>
 </body>

--- a/src/main/resources/templates/result-report.html
+++ b/src/main/resources/templates/result-report.html
@@ -14,52 +14,61 @@
 <body about="{subject}" prefix="{prefixes}">
 <header>
     <h1>Solid Specification - Conformance Test Suite Results</h1>
-    <h2>
-        <dl><dt>Specification under test</dt><dd><a href="{specification}" rel="doap:implements" title="Specification link">{specification}</a></dd></dl>
-    </h2>
-    {#with assertor}{#include assertor /}{/with}
-
+    {#include specification-header /}
     <h2>Target server description - TODO</h2>
 </header>
 
 <main>
-    {#if specificationTestCases}
-    <h2>Results by test feature</h2>
-    {#each specificationTestCases}
-    <div property="dcterms:hasPart" resource="{it.subject}">
-        <section about="{it.subject}" typeof="{it.typesList}">
-            <h3 property="dcterms:title">{it.title}</h3>
-            <p property="dcterms:description">{it.description}</p>
-            <table>
-                <tr>
-                    <th>TestCase</th>
-                    <th>Title</th>
-                    <th>Level</th>
-                    <th>Status</th>
-                    <th>Target</th>
-                    <th>Outcome</th>
-                    <th>Timestamp</th>
-                    <th>Scenario link</th>
-                </tr>
-                {#let anchor=it.anchor}
-                {#each it.testCases}
-                    {#include testcase link=anchor /}
-                {/each}
-                {/let}
-            </table>
-        </section>
-    </div>
-    {/each}
+    {#if specifications}
+    {#each specifications}
+    <section about="{it.subject}" typeof="{it.typesList}">
+        <h2>Specification: {it.subject}</h2>
+        {#if it.specificationRequirements}
+        <h2>Results by test feature</h2>
+        {#each it.specificationRequirements}
+        <div about="{it.subject}" rel="spec:requirement" typeof="{it.typesList}">
+            <h3>Requirement: {it.subject}</h3>
+            <dl><dt>Conformance Role</dt><dd>{it.conformanceRole}</dd></dl>
+            <dl><dt>Conformance Level</dt><dd>{it.conformanceLevel}</dd></dl>
+            {#with it.specificationTestCase}
+            <div about="{subject}" rev="td:specificationReference" resource="{it.subject}" typeof="{it.typesList}">
+                <h3 property="dcterms:title">{title}</h3>
+                <p property="dcterms:description">{description}</p>
+                {#if testCases}
+                <table>
+                    <tr>
+                        <th>TestCase</th>
+                        <th>Title</th>
+                        <th>Level</th>
+                        <th>Status</th>
+                        <th>Target</th>
+                        <th>Outcome</th>
+                        <th>Timestamp</th>
+                        <th>Scenario link</th>
+                    </tr>
+                    {#each testCases}
+                        {#include testcase link=anchor /}
+                    {/each}
+                </table>
+                {#else}
+                <p>No test cases found</p>
+                {/if}
+            </div>
+            {/with}
+        </div>
+        {/each}
 
-    <hr/>
-    <h2>Results by test scenario</h2>
-    {#each specificationTestCases}
-    <div id="scenarios-{it.anchor}" property="dcterms:hasPart" resource="{it.subject}">
-        <section about="{it.subject}" typeof="{it.typesList}">
-            <h3 property="dcterms:title">{it.title}</h3>
-            {#each it.testCases}
-            {#if it.scenarios}
+        <hr/>
+        <h2>Results by test scenario</h2>
+        {#for requirement in it.specificationRequirements}
+        {#let stc=requirement.specificationTestCase}
+        <div id="scenarios-{stc.anchor}" property="dcterms:hasPart" resource="{stc.subject}">
+            <section about="{stc.subject}" typeof="{stc.typesList}">
+                <h3 property="dcterms:title">{stc.title}</h3>
+                {#if stc.testCases}
+                {#each stc.testCases}
                 <h3 property="dcterms:title">{it.title}</h3>
+                {#if it.scenarios}
                 <table>
                     <tr>
                         <th>Scenario</th>
@@ -71,14 +80,24 @@
                     {#include scenario /}
                     {/each}
                 </table>
-            {/if}
-            {/each}
-        </section>
-    </div>
+                {#else}
+                <p>No scenario results were discovered.</p>
+                {/if}
+                {/each}
+                {#else}
+                <p>No test cases were found.</p>
+                {/if}
+            </section>
+        </div>
+        {/let}
+        {/for}
+        {#else}
+        <p>No tests were discovered.</p>
+        {/if}
+    </section>
     {/each}
-    {#else}
-    <p>No tests were discovered.</p>
     {/if}
+
 </main>
 </body>
 </html>

--- a/src/main/resources/templates/specification-header.html
+++ b/src/main/resources/templates/specification-header.html
@@ -1,0 +1,13 @@
+<h2>Specifications under test</h2>
+{#if specifications}
+<ul>
+  {#each specifications}
+  <li><a href="{it.subject}" typeof="{it.typesList}" title="Specification link">{it.subject}</a>
+    {#if it.manifest} - Test manifest: <a href="{it.manifest}" rel="rdfs:seeAlso" title="Manifest link">{it.manifest}</a>{/if}
+  </li>
+  {/each}
+</ul>
+{#else}
+<p>No specifications found.</p>
+{/if}
+{#with assertor}{#include assertor /}{/with}

--- a/src/test/java/org/solid/testharness/config/PathMappingsTest.java
+++ b/src/test/java/org/solid/testharness/config/PathMappingsTest.java
@@ -65,7 +65,7 @@ class PathMappingsTest {
                 pathMappingString("https://example.org/features", "src/test/resources"),
                 pathMappingString("https://example.org/specification", "src/test/resources/discovery/specification"),
                 pathMappingString("https://example.org/manifests", "src/test/resources/discovery"),
-                pathMappingString("https://example.org/badmapping", "http://example.org:-1")
+                pathMappingString("https://example.org/badmapping", "https://example.org:-1")
                 )) + "]", pathMappings.toString());
     }
 
@@ -163,6 +163,18 @@ class PathMappingsTest {
     void mapFeatureIri() {
         final URI path = pathMappings.mapFeatureIri(iri("https://example.org/dummy/group1/test.feature"));
         assertEquals(TestUtils.getPathUri("src/test/resources/dummy-features/group1/test.feature"), path);
+    }
+
+    @Test
+    void mapIri() throws MalformedURLException {
+        final URL url = pathMappings.mapIri(iri("https://example.org/manifests/test-manifest-sample-1.ttl"));
+        assertEquals(TestUtils.getFileUrl("src/test/resources/discovery/test-manifest-sample-1.ttl"), url);
+    }
+
+    @Test
+    void mapIriNoMapping() throws MalformedURLException {
+        final URL url = pathMappings.mapIri(iri("https://example.org/unknown/test.ttl"));
+        assertEquals(new URL("https://example.org/unknown/test.ttl"), url);
     }
 
     @Test

--- a/src/test/java/org/solid/testharness/reporting/ReportGeneratorNoRepositoryTest.java
+++ b/src/test/java/org/solid/testharness/reporting/ReportGeneratorNoRepositoryTest.java
@@ -55,7 +55,7 @@ class ReportGeneratorNoRepositoryTest {
     void buildHtmlCoverageReportBadResult() {
         final RepositoryConnection conn = mock(RepositoryConnection.class);
         when(dataRepository.getConnection()).thenReturn(conn);
-        when(conn.prepareTupleQuery(any())).thenThrow(new RepositoryException("BAD RESULT"));
+        when(conn.getStatements(any(), any(), any())).thenThrow(new RepositoryException("BAD RESULT"));
         final StringWriter sw = new StringWriter();
         assertThrows(RepositoryException.class, () -> reportGenerator.buildHtmlCoverageReport(sw));
     }

--- a/src/test/java/org/solid/testharness/reporting/ReportGeneratorNoRepositoryTest.java
+++ b/src/test/java/org/solid/testharness/reporting/ReportGeneratorNoRepositoryTest.java
@@ -28,7 +28,6 @@ import io.quarkus.test.junit.mockito.InjectMock;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.RepositoryException;
 import org.junit.jupiter.api.Test;
-import org.solid.common.vocab.DOAP;
 import org.solid.testharness.utils.DataRepository;
 
 import javax.inject.Inject;
@@ -56,7 +55,7 @@ class ReportGeneratorNoRepositoryTest {
     void buildHtmlCoverageReportBadResult() {
         final RepositoryConnection conn = mock(RepositoryConnection.class);
         when(dataRepository.getConnection()).thenReturn(conn);
-        when(conn.getStatements(null, DOAP.implements_, null)).thenThrow(new RepositoryException("BAD RESULT"));
+        when(conn.prepareTupleQuery(any())).thenThrow(new RepositoryException("BAD RESULT"));
         final StringWriter sw = new StringWriter();
         assertThrows(RepositoryException.class, () -> reportGenerator.buildHtmlCoverageReport(sw));
     }

--- a/src/test/java/org/solid/testharness/reporting/ReportGeneratorTest.java
+++ b/src/test/java/org/solid/testharness/reporting/ReportGeneratorTest.java
@@ -69,6 +69,8 @@ class ReportGeneratorTest {
         dataRepository.load(TestUtils.getFileUrl("src/test/resources/config/config-sample.ttl"));
         dataRepository.load(TestUtils.getFileUrl("src/test/resources/discovery/specification-sample-1.ttl"));
         dataRepository.load(TestUtils.getFileUrl("src/test/resources/discovery/test-manifest-sample-1.ttl"));
+        dataRepository.load(TestUtils.getFileUrl("src/test/resources/discovery/specification-sample-2.ttl"));
+        dataRepository.load(TestUtils.getFileUrl("src/test/resources/discovery/test-manifest-sample-2.ttl"));
         dataRepository.load(TestUtils.getFileUrl("src/test/resources/reporting/testsuite-results-sample.ttl"));
         final StringWriter sw = new StringWriter();
         reportGenerator.buildHtmlResultReport(sw);
@@ -81,6 +83,8 @@ class ReportGeneratorTest {
         dataRepository.load(TestUtils.getFileUrl("src/test/resources/config/harness-sample.ttl"));
         dataRepository.load(TestUtils.getFileUrl("src/test/resources/discovery/specification-sample-1.ttl"));
         dataRepository.load(TestUtils.getFileUrl("src/test/resources/discovery/test-manifest-sample-1.ttl"));
+        dataRepository.load(TestUtils.getFileUrl("src/test/resources/discovery/specification-sample-2.ttl"));
+        dataRepository.load(TestUtils.getFileUrl("src/test/resources/discovery/test-manifest-sample-2.ttl"));
         dataRepository.load(TestUtils.getFileUrl("src/test/resources/reporting/coverage-sample.ttl"));
         final StringWriter sw = new StringWriter();
         reportGenerator.buildHtmlCoverageReport(sw);
@@ -95,6 +99,8 @@ class ReportGeneratorTest {
         dataRepository.load(TestUtils.getFileUrl("src/test/resources/config/config-sample.ttl"));
         dataRepository.load(TestUtils.getFileUrl("src/test/resources/discovery/specification-sample-1.ttl"));
         dataRepository.load(TestUtils.getFileUrl("src/test/resources/discovery/test-manifest-sample-1.ttl"));
+        dataRepository.load(TestUtils.getFileUrl("src/test/resources/discovery/specification-sample-2.ttl"));
+        dataRepository.load(TestUtils.getFileUrl("src/test/resources/discovery/test-manifest-sample-2.ttl"));
         dataRepository.load(TestUtils.getFileUrl("src/test/resources/reporting/testsuite-results-sample.ttl"));
         final Writer wr = Files.newBufferedWriter(reportFile.toPath());
         reportGenerator.buildHtmlResultReport(wr);
@@ -108,6 +114,8 @@ class ReportGeneratorTest {
         dataRepository.load(TestUtils.getFileUrl("src/test/resources/config/harness-sample.ttl"));
         dataRepository.load(TestUtils.getFileUrl("src/test/resources/discovery/specification-sample-1.ttl"));
         dataRepository.load(TestUtils.getFileUrl("src/test/resources/discovery/test-manifest-sample-1.ttl"));
+        dataRepository.load(TestUtils.getFileUrl("src/test/resources/discovery/specification-sample-2.ttl"));
+        dataRepository.load(TestUtils.getFileUrl("src/test/resources/discovery/test-manifest-sample-2.ttl"));
         dataRepository.load(TestUtils.getFileUrl("src/test/resources/reporting/coverage-sample.ttl"));
         final Writer wr = Files.newBufferedWriter(reportFile.toPath());
         reportGenerator.buildHtmlCoverageReport(wr);
@@ -123,14 +131,14 @@ class ReportGeneratorTest {
     @Test
     void buildHtmlCoverageReportEmpty() {
         final StringWriter sw = new StringWriter();
-        assertThrows(NullPointerException.class, () -> reportGenerator.buildHtmlCoverageReport(sw));
+        assertDoesNotThrow(() -> reportGenerator.buildHtmlCoverageReport(sw));
     }
 
     @Test
     void buildHtmlCoverageReportBadSubject() throws IOException {
-        TestData.insertData(dataRepository, TestData.PREFIXES + "_:b0 doap:implements ex:spec .");
+        TestData.insertData(dataRepository, TestData.PREFIXES + "_:b0 a spec:Specification .");
         final StringWriter sw = new StringWriter();
-        assertThrows(NullPointerException.class, () -> reportGenerator.buildHtmlCoverageReport(sw));
+        assertThrows(ClassCastException.class, () -> reportGenerator.buildHtmlCoverageReport(sw));
     }
 }
 

--- a/src/test/java/org/solid/testharness/reporting/ResultDataTest.java
+++ b/src/test/java/org/solid/testharness/reporting/ResultDataTest.java
@@ -26,8 +26,8 @@ package org.solid.testharness.reporting;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
 import org.solid.testharness.utils.AbstractDataModelTests;
-import org.solid.testharness.utils.TestData;
 
+import java.util.Collections;
 import java.util.List;
 
 import static org.eclipse.rdf4j.model.util.Values.iri;
@@ -42,7 +42,7 @@ class ResultDataTest extends AbstractDataModelTests {
 
     @Test
     void getHtmlPrefixes() {
-        final ResultData resultData = new ResultData(iri(TestData.SAMPLE_NS));
+        final ResultData resultData = new ResultData(Collections.emptyList());
         assertEquals("rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns# " +
                 "rdfs: http://www.w3.org/2000/01/rdf-schema# " +
                 "xsd: http://www.w3.org/2001/XMLSchema# " +
@@ -51,26 +51,25 @@ class ResultDataTest extends AbstractDataModelTests {
                 "solid: http://www.w3.org/ns/solid/terms# " +
                 "solid-test: https://github.com/solid/conformance-test-harness/vocab# " +
                 "earl: http://www.w3.org/ns/earl# " +
-                "td: http://www.w3.org/2006/03/test-description#", resultData.getPrefixes());
+                "td: http://www.w3.org/2006/03/test-description# " +
+                "spec: http://www.w3.org/ns/spec#", resultData.getPrefixes());
     }
 
     @Test
-    void getSpecificationTestCases() {
-        final ResultData resultData = new ResultData(iri(TestData.SAMPLE_NS));
-        final List<SpecificationTestCase> testCases = resultData.getSpecificationTestCases();
-        assertNotNull(testCases);
-        assertEquals(2, testCases.size());
-    }
-
-    @Test
-    void getSpecification() {
-        final ResultData resultData = new ResultData(iri(TestData.SAMPLE_NS));
-        assertEquals("https://solidproject.org/TR/protocol#spec1", resultData.getSpecification());
+    void getSpecifications() {
+        final ResultData resultData = new ResultData(
+                List.of(iri("https://example.org/specification1"), iri("https://example.org/specification2"))
+        );
+        final List<Specification> specifications = resultData.getSpecifications();
+        assertNotNull(specifications);
+        assertEquals(2, specifications.size());
+        assertEquals(3, specifications.get(0).getSpecificationRequirements().size());
+        assertEquals(1, specifications.get(1).getSpecificationRequirements().size());
     }
 
     @Test
     void getAssertor() {
-        final ResultData resultData = new ResultData(iri(TestData.SAMPLE_NS));
+        final ResultData resultData = new ResultData(Collections.emptyList());
         assertNotNull(resultData.getAssertor());
     }
 }

--- a/src/test/java/org/solid/testharness/reporting/SpecificationRequirementTest.java
+++ b/src/test/java/org/solid/testharness/reporting/SpecificationRequirementTest.java
@@ -1,0 +1,71 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2021 Solid
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.solid.testharness.reporting;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.eclipse.rdf4j.model.IRI;
+import org.junit.jupiter.api.Test;
+import org.solid.common.vocab.SPEC;
+import org.solid.testharness.utils.AbstractDataModelTests;
+
+import static org.eclipse.rdf4j.model.util.Values.iri;
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+class SpecificationRequirementTest extends AbstractDataModelTests {
+    private static final IRI REQUIREMENT = iri(NS, "specification#requirement");
+    private static final IRI REQUIREMENT2 = iri(NS, "specification#requirement2");
+
+    @Override
+    public String getTestFile() {
+        return "src/test/resources/reporting/specification-requirement-testing-feature.ttl";
+    }
+
+    @Test
+    void getConformanceRole() {
+        final SpecificationRequirement requirement = new SpecificationRequirement(REQUIREMENT);
+        assertEquals(SPEC.ServerConformanceClass.stringValue(), requirement.getConformanceRole());
+    }
+
+    @Test
+    void getConformanceLevel() {
+        final SpecificationRequirement requirement = new SpecificationRequirement(REQUIREMENT);
+        assertEquals(SPEC.ConformanceMust.stringValue(), requirement.getConformanceLevel());
+    }
+
+    @Test
+    void getSpecificationTestCase() {
+        final SpecificationRequirement requirement = new SpecificationRequirement(REQUIREMENT);
+        final SpecificationTestCase specificationTestCase = requirement.getSpecificationTestCase();
+        assertNotNull(specificationTestCase);
+        assertEquals("Group 1", specificationTestCase.getTitle());
+    }
+
+    @Test
+    void getSpecificationTestCaseMissing() {
+        final SpecificationRequirement requirement = new SpecificationRequirement(REQUIREMENT2);
+        final SpecificationTestCase specificationTestCase = requirement.getSpecificationTestCase();
+        assertNull(specificationTestCase);
+    }
+}

--- a/src/test/java/org/solid/testharness/reporting/SpecificationTest.java
+++ b/src/test/java/org/solid/testharness/reporting/SpecificationTest.java
@@ -23,31 +23,33 @@
  */
 package org.solid.testharness.reporting;
 
-import org.eclipse.rdf4j.model.IRI;
-import org.solid.common.vocab.DCTERMS;
-import org.solid.common.vocab.TD;
-import org.solid.testharness.utils.DataModelBase;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+import org.solid.testharness.utils.AbstractDataModelTests;
 
 import java.util.List;
 
-public class SpecificationTestCase extends DataModelBase {
-    public SpecificationTestCase(final IRI subject) {
-        super(subject);
+import static org.eclipse.rdf4j.model.util.Values.iri;
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+class SpecificationTest extends AbstractDataModelTests {
+    @Override
+    public String getTestFile() {
+        return "src/test/resources/reporting/specification-testing-feature.ttl";
     }
 
-    public String getTitle() {
-        return getLiteralAsString(DCTERMS.title);
+    @Test
+    void getManifest() {
+        final Specification specification = new Specification(iri(NS, "specification1"));
+        assertEquals("https://example.org/manifests/test-manifest.ttl", specification.getManifest());
     }
 
-    public String getDescription() {
-        return getLiteralAsString(DCTERMS.description);
-    }
-
-    public String getSpecificationReference() {
-        return getIriAsString(TD.specificationReference);
-    }
-
-    public List<TestCase> getTestCases() {
-        return getModelList(DCTERMS.hasPart, TestCase.class);
+    @Test
+    void getSpecificationRequirements() {
+        final Specification specification = new Specification(iri(NS, "specification1"));
+        final List<SpecificationRequirement> specificationRequirements = specification.getSpecificationRequirements();
+        assertEquals(3, specificationRequirements.size());
+        assertEquals("https://example.org/specification1#spec1", specificationRequirements.get(0).getSubject());
     }
 }

--- a/src/test/java/org/solid/testharness/reporting/TestSuiteDescriptionNoRepositoryTest.java
+++ b/src/test/java/org/solid/testharness/reporting/TestSuiteDescriptionNoRepositoryTest.java
@@ -33,6 +33,7 @@ import org.solid.testharness.utils.DataRepository;
 import org.solid.testharness.utils.TestHarnessInitializationException;
 
 import javax.inject.Inject;
+import java.net.URL;
 import java.util.List;
 
 import static org.eclipse.rdf4j.model.util.Values.iri;
@@ -46,6 +47,14 @@ class TestSuiteDescriptionNoRepositoryTest {
 
     @Inject
     TestSuiteDescription testSuiteDescription;
+
+    @Test
+    void loadException() {
+        when(dataRepository.getConnection()).thenThrow(new RepositoryException("BAD REPOSITORY"));
+        assertThrows(TestHarnessInitializationException.class,
+                () -> testSuiteDescription.load(List.of(new URL("https://example.org/specification-sample-1.ttl"))));
+
+    }
 
     @Test
     void locateTestCasesException() {

--- a/src/test/java/org/solid/testharness/utils/DataModelBaseTest.java
+++ b/src/test/java/org/solid/testharness/utils/DataModelBaseTest.java
@@ -245,9 +245,15 @@ class DataModelBaseTest extends AbstractDataModelTests {
         final LocalDateTime dateTime = dataModelBase.getLiteralAsDateTime(iri(NS, "hasDateTime"));
         assertThat("DateTime matches", dateTime.isEqual(LocalDateTime.parse("2021-04-08T12:30:00.000")));
     }
+
     @Test
     void getMissingLiteralAsDateTime() {
         assertNull(dataModelBase.getLiteralAsDateTime(iri(NS, "hasMissingDateTime")));
+    }
+
+    @Test
+    void getAnchor() {
+        assertEquals("test", dataModelBase.getAnchor());
     }
 
     class TestClass extends DataModelBase {

--- a/src/test/java/org/solid/testharness/utils/DataModelBaseTest.java
+++ b/src/test/java/org/solid/testharness/utils/DataModelBaseTest.java
@@ -35,6 +35,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.eclipse.rdf4j.model.util.Values.iri;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -53,7 +54,6 @@ class DataModelBaseTest extends AbstractDataModelTests {
     @Override
     public String getTestFile() {
         return "src/test/resources/reporting/datamodelbase-testing-feature.ttl";
-
     }
 
     @Test
@@ -84,8 +84,22 @@ class DataModelBaseTest extends AbstractDataModelTests {
 
     @Test
     void sizeList() {
-        final DataModelBase listModel = new DataModelBase(iri(NS, "test"), DataModelBase.ConstructMode.LIST);
-        assertEquals(17, listModel.size());
+        final DataModelBase listModel = new DataModelBase(iri(NS, "test"), DataModelBase.ConstructMode.DEEP_WITH_LISTS);
+        assertEquals(19, listModel.size());
+    }
+
+    @Test
+    void sizeRequirement() {
+        final DataModelBase reqModel = new DataModelBase(iri(NS, "requirement"),
+                DataModelBase.ConstructMode.SHALLOW);
+        assertEquals(3, reqModel.size());
+    }
+
+    @Test
+    void sizeRequirementIncRefs() {
+        final DataModelBase reqModel = new DataModelBase(iri(NS, "requirement"),
+                DataModelBase.ConstructMode.INC_REFS);
+        assertEquals(4, reqModel.size());
     }
 
     @Test
@@ -124,7 +138,7 @@ class DataModelBaseTest extends AbstractDataModelTests {
 
     @Test
     void getModelCollectionList() {
-        final DataModelBase listModel = new DataModelBase(iri(NS, "test"), DataModelBase.ConstructMode.LIST);
+        final DataModelBase listModel = new DataModelBase(iri(NS, "test"), DataModelBase.ConstructMode.DEEP_WITH_LISTS);
         final List<Step> models = listModel.getModelCollectionList(iri(NS, "hasSteps"), Step.class);
         assertNotNull(models);
         assertEquals(2, models.size());
@@ -133,14 +147,14 @@ class DataModelBaseTest extends AbstractDataModelTests {
 
     @Test
     void getEmptyModelCollectionList() {
-        final DataModelBase listModel = new DataModelBase(iri(NS, "test"), DataModelBase.ConstructMode.LIST);
+        final DataModelBase listModel = new DataModelBase(iri(NS, "test"), DataModelBase.ConstructMode.DEEP_WITH_LISTS);
         final List<Step> models = listModel.getModelCollectionList(iri(NS, "hasSteps2"), Step.class);
         assertNull(models);
     }
 
     @Test
     void getBadModelCollectionList() {
-        final DataModelBase listModel = new DataModelBase(iri(NS, "test"), DataModelBase.ConstructMode.LIST);
+        final DataModelBase listModel = new DataModelBase(iri(NS, "test"), DataModelBase.ConstructMode.DEEP_WITH_LISTS);
         assertThrows(RuntimeException.class,
                 () -> listModel.getModelCollectionList(iri(NS, "hasSteps"), TestClass.class)
         );
@@ -260,5 +274,9 @@ class DataModelBaseTest extends AbstractDataModelTests {
         public TestClass() {
             super(null);
         }
+    }
+
+    private String modelToString(final DataModelBase data) {
+        return data.model.stream().map(Object::toString).collect(Collectors.joining("\n"));
     }
 }

--- a/src/test/java/org/solid/testharness/utils/DataRepositoryTest.java
+++ b/src/test/java/org/solid/testharness/utils/DataRepositoryTest.java
@@ -29,12 +29,12 @@ import io.quarkus.test.junit.QuarkusTest;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.util.Values;
-import org.eclipse.rdf4j.model.vocabulary.FOAF;
-import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.solid.common.vocab.FOAF;
+import org.solid.common.vocab.RDF;
 
 import java.io.*;
 import java.net.MalformedURLException;
@@ -261,7 +261,7 @@ class DataRepositoryTest {
         final DataRepository dataRepository = new DataRepository();
         try (RepositoryConnection conn = dataRepository.getConnection()) {
             final Statement st = Values.getValueFactory()
-                    .createStatement(iri(TestData.SAMPLE_NS, "bob"), RDF.TYPE, FOAF.PERSON);
+                    .createStatement(iri(TestData.SAMPLE_NS, "bob"), RDF.type, FOAF.Person);
             conn.add(st);
         }
         return dataRepository;

--- a/src/test/resources/discovery/test-manifest-sample-1.ttl
+++ b/src/test/resources/discovery/test-manifest-sample-1.ttl
@@ -7,11 +7,6 @@
 
 @prefix manifest: <https://example.org/manifests/test-manifest-sample-1.ttl#> .
 
-# to be removed
-@prefix doap: <http://usefulinc.com/ns/doap#> .
-manifest: doap:implements <https://example.org/specification1> ;
-          dcterms:hasPart manifest:group1, manifest:group2, manifest:group3 .
-
 manifest:group1
     a td:SpecificationTestCase ;
     dcterms:title "Group 1"@en ;

--- a/src/test/resources/discovery/test-manifest-sample-2.ttl
+++ b/src/test/resources/discovery/test-manifest-sample-2.ttl
@@ -7,11 +7,6 @@
 
 @prefix manifest: <https://example.org/manifests/test-manifest-sample-2.ttl#> .
 
-# to be removed
-@prefix doap: <http://usefulinc.com/ns/doap#> .
-manifest: doap:implements <https://solidproject.org/TR/protocol> ;
-          dcterms:hasPart manifest:group4 .
-
 manifest:group4
     a td:SpecificationTestCase ;
     dcterms:title "Group 4"@en ;

--- a/src/test/resources/reporting/datamodelbase-testing-feature.ttl
+++ b/src/test/resources/reporting/datamodelbase-testing-feature.ttl
@@ -17,3 +17,15 @@ ex:test
 ex:test1 a earl:TestCase .
 ex:step1 a earl:Step .
 ex:step2 a earl:Step .
+
+ex:requirement
+    a ex:NormativeRequirement ;
+    ex:conformanceRole ex:ServerConformanceClass ;
+    ex:normativeConformanceLevel ex:ConformanceMust
+.
+
+ex:group1
+    a ex:SpecificationTestCase ;
+    ex:title "Group 1"@en ;
+    ex:specificationReference ex:requirement
+.

--- a/src/test/resources/reporting/specification-requirement-testing-feature.ttl
+++ b/src/test/resources/reporting/specification-requirement-testing-feature.ttl
@@ -1,0 +1,22 @@
+@prefix td: <http://www.w3.org/2006/03/test-description#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix spec: <http://www.w3.org/ns/spec#> .
+@prefix manifest: <https://example.org/manifests/test-manifest-sample-1.ttl#> .
+
+<https://example.org/specification#requirement>
+    a spec:NormativeRequirement ;
+    spec:conformanceRole spec:ServerConformanceClass ;
+    spec:normativeConformanceLevel spec:ConformanceMust
+.
+
+manifest:group1
+    a td:SpecificationTestCase ;
+    dcterms:title "Group 1"@en ;
+    td:specificationReference <https://example.org/specification#requirement>
+.
+
+<https://example.org/specification#requirement2>
+    a spec:NormativeRequirement ;
+    spec:conformanceRole spec:ServerConformanceClass ;
+    spec:normativeConformanceLevel spec:ConformanceMust
+.

--- a/src/test/resources/reporting/specification-testing-feature.ttl
+++ b/src/test/resources/reporting/specification-testing-feature.ttl
@@ -8,9 +8,3 @@
                      <https://example.org/specification1#spec3> ;
     rdfs:seeAlso <https://example.org/manifests/test-manifest.ttl>
 .
-
-<https://example.org/specification2>
-    a spec:Specification ;
-    spec:requirement <https://example.org/specification2#spec1> ;
-    rdfs:seeAlso <https://example.org/manifests/test-manifest2.ttl>
-.


### PR DESCRIPTION
The link between specs and tests is still under development and is likely to change. In particular, the way DataModelBase has to query test get the SpecificationTestCases linked to a SpecificationRequirement is a bit awkward as a result of the current design.

The main changes are the ReportGenerator, ResultData and the various Specification* classes that represent the data as beans for use in the HTML reports. The RDFa in the reports in not yet complete - there is a task for this to be completed later.