### PR TITLE
Improve command line report options

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -12,7 +12,7 @@ have full control over the container, either because `alice` owns the POD or bec
 granted full control access.   
 
 # Configuration
-The test harness relies on uyp to 4 sources of configuration, depending on how the data is likely to be used
+The test harness relies on up to 4 sources of configuration, depending on how the data is likely to be used
 and how dynamic it is. They are as follows (in order of least dynamic to most).
 
 ## Test subject description
@@ -28,7 +28,7 @@ An examnple of this file is provided, containing descriptions of the following S
 
 There are some test subject specific configuration properties in this file:
 ```
-  solid-test:origin <https://tester>   # registered origin for session-based lgin
+  solid-test:origin <https://tester>   # registered origin for session-based login
   solid-test:maxThreads 8              # number of threads for running tests in parallel  
   solid-test:features "authentication", "acl", "wac-allow"  # server capabilities
 ```
@@ -66,7 +66,7 @@ readTimeout: 1000		# default = 5000
 The test harness needs to know the root URL of the server being tested and the path to the container in which test files
 will be created.
 ```
-SERVER_ROOT=	# e.g. https://pod-compat.inrupt.com or https://pod-user.inrupt.net
+RESOURCE_SERVER_ROOT=	# e.g. https://pod-compat.inrupt.com or https://pod-user.inrupt.net
 TEST_CONTAINER= # e.g. pod-user/test or test
 ```
 These are used to construct the root location for test files e.g. `https://pod-compat.inrupt.com/pod-user/test/`
@@ -169,7 +169,7 @@ in the test subject configuration file describing the server under test.
 
 This mechanism will work in CI environments where the credentials can be passed in as secrets.
 
-### Command line options
+## Command line options
 
 The command line options are:
 ```
@@ -181,18 +181,20 @@ usage: run
  -s,--source <arg>   URL or path to test source(s)
     --subjects <arg> URL or path to test subject config (Turtle)
  -t,--target <arg>   target server
+    --tests          produce a test report
 ```
+If neither `--coverage` nor `--tests` is specified then the default action is to run the tests and produce both reports.
 
-## Execution
+# Execution
 
-### Running in a container
+## Running in a container
 The simplest way to run the test harness is via the docker image published to
 https://hub.docker.com/repository/docker/solidconformancetestbeta/conformance-test-harness
 
 The following examples demonstrate how a script can fetch example tests and configuration files from the repository and
 run tests against a publicly available server or one that is also running in a container.
 
-#### ESS (ACL compatibility mode)
+### ESS (ACL compatibility mode)
 Create a file for environment variables e.g. `ess-compat.env` with the following contents (based on the 
 client_credentials option):
 ```shell
@@ -201,7 +203,7 @@ ALICE_WEBID=
 ALICE_CLIENT_SECRET=
 BOB_WEBID=
 BOB_CLIENT_SECRET=
-SERVER_ROOT=https://pod-compat.inrupt.com
+RESOURCE_SERVER_ROOT=https://pod-compat.inrupt.com
 TEST_CONTAINER=/pod-owner/shared-test/
 ```
 Next create a script based on the following:
@@ -242,13 +244,12 @@ EOF
 
 # run the tests in the test harness
 docker pull solidconformancetestbeta/conformance-test-harness
-docker run -i --rm -v "$(pwd)":/data --env-file=ess-compat.env solidconformancetestbeta/conformance-test-harness --coverage
 docker run -i --rm -v "$(pwd)":/data --env-file=ess-compat.env solidconformancetestbeta/conformance-test-harness
 ```
 
 Run `./ess-compat.sh` and the reports will be created in the current directory. 
 
-#### CSS in a container
+### CSS in a container
 Create a file for environment variables e.g. `css.env` with the following contents (based on the client_credentials
 option):
 ```shell
@@ -257,7 +258,7 @@ ALICE_WEBID=
 ALICE_CLIENT_SECRET=
 BOB_WEBID=
 BOB_CLIENT_SECRET=
-SERVER_ROOT=http://server:3000
+RESOURCE_SERVER_ROOT=http://server:3000
 TEST_CONTAINER=/test/
 ```
 Note that when using a container you can't use http://localhost:3000 as this will not be accessible to the test harness
@@ -316,7 +317,6 @@ docker run -d --name=server --network=testnet -p 3000:3000 -it css:latest
 
 # run the tests in the test harness
 docker pull solidconformancetestbeta/conformance-test-harness
-docker run -i --rm -v "$(pwd)":/data --env-file=css.env solidconformancetestbeta/conformance-test-harness --coverage
 docker run -i --rm -v "$(pwd)":/data --env-file=css.env --network=testnet solidconformancetestbeta/conformance-test-harness
 docker stop server
 docker rm server
@@ -324,7 +324,7 @@ docker rm server
 
 Run `./css.sh` and the reports will be created in the current directory.
 
-### Local execution
+## Local execution
 The test harness is packaged into a single, executable jar which is available as an asset in the release within github:
 https://github.com/solid/conformance-test-harness/releases. The only dependency is on Java 11. You can run it and see
 its usage as follows:
@@ -332,7 +332,7 @@ its usage as follows:
 java -jar solid-conformance-test-harness-runner.jar --help
 ```
 
-## Reports
+# Reports
 |Report|Location|
 |------|--------|
 |Coverage (HTML+RDFa)|`coverage.html`|

--- a/pom.xml
+++ b/pom.xml
@@ -486,7 +486,7 @@
                         <configuration>
                             <excludedGroups>solid</excludedGroups>
                             <environmentVariables>
-                                <SERVER_ROOT>https://example.org</SERVER_ROOT>
+                                <RESOURCE_SERVER_ROOT>https://example.org</RESOURCE_SERVER_ROOT>
                                 <TEST_CONTAINER>/solid-test-suite-alice/shared-test/</TEST_CONTAINER>
                                 <SOLID_IDENTITY_PROVIDER>https://broker.example.org/</SOLID_IDENTITY_PROVIDER>
                                 <ALICE_WEBID>https://example.org/solid-test-suite-alice/profile/card#me</ALICE_WEBID>

--- a/scripts/css.sh
+++ b/scripts/css.sh
@@ -38,7 +38,6 @@ docker run -d --name=server --network=testnet -p 3000:3000 -it css:latest
 
 # run the tests in the test harness
 docker pull solidconformancetestbeta/conformance-test-harness
-docker run -i --rm -v "$(pwd)":/data --env-file=css.env solidconformancetestbeta/conformance-test-harness --coverage
 docker run -i --rm -v "$(pwd)":/data --env-file=css.env --network=testnet solidconformancetestbeta/conformance-test-harness
 docker stop server
 docker rm server

--- a/scripts/ess.sh
+++ b/scripts/ess.sh
@@ -20,7 +20,7 @@ subjects: ./test-subjects.ttl
 sources:
   - https://raw.githubusercontent.com/solid/conformance-test-harness/main/example/solid-protocol-spec.ttl
   - https://raw.githubusercontent.com/solid/conformance-test-harness/main/example/web-access-control-spec.ttl
-target: https://github.com/solid/conformance-test-harness/ess-compat
+target: https://github.com/solid/conformance-test-harness/ess
 
 feature:
   mappings:
@@ -34,4 +34,4 @@ EOF
 
 # run the tests in the test harness
 docker pull solidconformancetestbeta/conformance-test-harness
-docker run -i --rm -v "$(pwd)":/data --env-file=ess-compat.env solidconformancetestbeta/conformance-test-harness
+docker run -i --rm -v "$(pwd)":/data --env-file=ess.env solidconformancetestbeta/conformance-test-harness

--- a/src/main/java/org/solid/testharness/ConformanceTestHarness.java
+++ b/src/main/java/org/solid/testharness/ConformanceTestHarness.java
@@ -99,13 +99,13 @@ public class ConformanceTestHarness {
                         .build());
             }
         }
+        config.logConfigSettings();
+        testSuiteDescription.load(config.getTestSources());
     }
 
     public boolean createCoverageReport() {
-        config.logConfigSettings();
         logger.info("===================== DISCOVER TESTS ========================");
         try {
-            testSuiteDescription.load(config.getTestSources());
             final List<IRI> testCases = testSuiteDescription.getAllTestCases();
             final List<String> featurePaths = testSuiteDescription.locateTestCases(testCases);
             if (featurePaths.isEmpty()) {
@@ -136,12 +136,10 @@ public class ConformanceTestHarness {
     }
 
     public TestSuiteResults runTestSuites(final List<String> filters) {
-        config.logConfigSettings();
         logger.info("===================== DISCOVER TESTS ========================");
         final List<String> featurePaths;
         try {
-            testSuiteDescription.load(config.getTestSources());
-            testSubject.loadTestSubjectConfig(); // TODO:is this in right place?
+            testSubject.loadTestSubjectConfig();
             // TODO: Consider running some initial tests to discover the features provided by a server
             final List<IRI> testCases = testSuiteDescription.getSupportedTestCases(
                     testSubject.getTargetServer().getFeatures().keySet()

--- a/src/main/java/org/solid/testharness/config/Config.java
+++ b/src/main/java/org/solid/testharness/config/Config.java
@@ -81,7 +81,7 @@ public class Config {
     String solidIdentityProvider;
     @ConfigProperty(name = "LOGIN_ENDPOINT")
     Optional<String> loginEndpoint;
-    @ConfigProperty(name = "SERVER_ROOT")
+    @ConfigProperty(name = "RESOURCE_SERVER_ROOT")
     String serverRoot;
     @ConfigProperty(name = "TEST_CONTAINER")
     String testContainer;

--- a/src/test/java/org/solid/testharness/ApplicationTest.java
+++ b/src/test/java/org/solid/testharness/ApplicationTest.java
@@ -154,6 +154,7 @@ class ApplicationTest {
     @Test
     void targetBlank() {
         final TestSuiteResults results = mockResults(0);
+        when(conformanceTestHarness.createCoverageReport()).thenReturn(true);
         when(conformanceTestHarness.runTestSuites(any())).thenReturn(results);
         assertEquals(0, application.run("--target", ""));
         verify(config, never()).setTestSubject(any());
@@ -163,7 +164,7 @@ class ApplicationTest {
     void target() {
         final TestSuiteResults results = mockResults(0);
         when(conformanceTestHarness.runTestSuites(any())).thenReturn(results);
-        assertEquals(0, application.run("--target", "test"));
+        assertEquals(0, application.run("--tests", "--target", "test"));
         verify(config).setTestSubject(iri(Namespaces.TEST_HARNESS_URI, "test"));
     }
 
@@ -171,7 +172,7 @@ class ApplicationTest {
     void targetIri() {
         final TestSuiteResults results = mockResults(0);
         when(conformanceTestHarness.runTestSuites(any())).thenReturn(results);
-        assertEquals(0, application.run("--target", "http://example.org/test"));
+        assertEquals(0, application.run("--tests", "--target", "http://example.org/test"));
         verify(config).setTestSubject(iri("http://example.org/test"));
     }
 
@@ -192,14 +193,14 @@ class ApplicationTest {
     void subjectsSet() {
         final TestSuiteResults results = mockResults(0);
         when(conformanceTestHarness.runTestSuites(any())).thenReturn(results);
-        assertEquals(0, application.run("--subjects", "subjectsfile"));
+        assertEquals(0, application.run("--tests", "--subjects", "subjectsfile"));
         verify(config).setSubjectsUrl("subjectsfile");
     }
 
     @Test
     void filtersBlank() {
         final ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
-        application.run("--filter", "");
+        application.run("--tests", "--filter", "");
         verify(conformanceTestHarness).runTestSuites(captor.capture());
         assertTrue(captor.getValue().isEmpty());
     }
@@ -207,7 +208,7 @@ class ApplicationTest {
     @Test
     void filters1() {
         final ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
-        application.run("--filter", "filter1");
+        application.run("--tests", "--filter", "filter1");
         verify(conformanceTestHarness).runTestSuites(captor.capture());
         assertEquals(1, captor.getValue().size());
         assertTrue(captor.getValue().contains("filter1"));
@@ -216,7 +217,7 @@ class ApplicationTest {
     @Test
     void filters2() {
         final ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
-        application.run("--filter", "filter1,filter2");
+        application.run("--tests", "--filter", "filter1,filter2");
         verify(conformanceTestHarness).runTestSuites(captor.capture());
         assertEquals(2, captor.getValue().size());
         assertTrue(captor.getValue().contains("filter1"));
@@ -226,7 +227,7 @@ class ApplicationTest {
     @Test
     void filtersTwice() {
         final ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
-        application.run("--filter", "filter1", "--filter", "filter2");
+        application.run("--tests", "--filter", "filter1", "--filter", "filter2");
         verify(conformanceTestHarness).runTestSuites(captor.capture());
         assertEquals(2, captor.getValue().size());
         assertTrue(captor.getValue().contains("filter1"));
@@ -236,20 +237,40 @@ class ApplicationTest {
     @Test
     void runTestSuitesNoResults() {
         when(conformanceTestHarness.runTestSuites(any())).thenReturn(null);
-        assertEquals(1, application.run());
+        assertEquals(1, application.run("--tests"));
     }
 
     @Test
     void runTestSuitesFailures() {
         final TestSuiteResults results = mockResults(1);
         when(conformanceTestHarness.runTestSuites(any())).thenReturn(results);
-        assertEquals(1, application.run());
+        assertEquals(1, application.run("--tests"));
     }
 
     @Test
-    void coverageReport() {
+    void coverageReportOnly() {
         when(conformanceTestHarness.createCoverageReport()).thenReturn(true);
         assertEquals(0, application.run("--coverage"));
+    }
+
+    @Test
+    void coverageAndTestReportNoOptions() {
+        when(conformanceTestHarness.createCoverageReport()).thenReturn(true);
+        final TestSuiteResults results = mockResults(0);
+        when(conformanceTestHarness.runTestSuites(any())).thenReturn(results);
+        assertEquals(0, application.run());
+        verify(conformanceTestHarness).createCoverageReport();
+        verify(conformanceTestHarness).runTestSuites(any());
+    }
+
+    @Test
+    void coverageAndTestReportBothOptions() {
+        when(conformanceTestHarness.createCoverageReport()).thenReturn(true);
+        final TestSuiteResults results = mockResults(0);
+        when(conformanceTestHarness.runTestSuites(any())).thenReturn(results);
+        assertEquals(0, application.run("--coverage", "--tests"));
+        verify(conformanceTestHarness).createCoverageReport();
+        verify(conformanceTestHarness).runTestSuites(any());
     }
 
     @Test

--- a/src/test/java/org/solid/testharness/config/ConfigTestNormalProfile.java
+++ b/src/test/java/org/solid/testharness/config/ConfigTestNormalProfile.java
@@ -40,7 +40,7 @@ public class ConfigTestNormalProfile implements QuarkusTestProfile {
         return Map.of(
                 "SOLID_IDENTITY_PROVIDER", "https://idp.example.org",
                 "LOGIN_ENDPOINT", "https://example.org/login/password",
-                "SERVER_ROOT", "https://target.example.org",
+                "RESOURCE_SERVER_ROOT", "https://target.example.org",
                 "TEST_CONTAINER", "test",
                 "ALICE_WEBID", "https://alice.target.example.org/profile/card#me",
                 "BOB_WEBID", "https://bob.target.example.org/profile/card#me"


### PR DESCRIPTION
Make default to run coverage and test reports with option to run just one. This means you can run with one docker command.
Also renamed SERVER_ROOT to RESOURCE_SERVER_ROOT