### PR TITLE
Config enhancements

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -275,6 +275,7 @@ usage: run
  -f,--filter <arg>   feature filter(s)
  -h,--help           print this message
  -o,--output <arg>   output directory
+    --skip-teardown  skip teardown (when server itself is being stopped)
  -s,--source <arg>   URL or path to test source(s)
     --subjects <arg> URL or path to test subject config (Turtle)
  -t,--target <arg>   target server

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -41,6 +41,9 @@
   agent: AGENT
   connectTimeout: 1000
   readTimeout: 1000
+  maxThreads: 4
+  origin: https://testharness
+  setupRootAcl: true
 
 "%blank":
   quarkus:

--- a/config/test-subjects.ttl
+++ b/config/test-subjects.ttl
@@ -22,8 +22,6 @@ prefix dcterms: <http://purl.org/dc/terms/>
     doap:homepage <https://inrupt.com/products/enterprise-solid-server>;
     doap:description "A production-grade Solid server produced and supported by Inrupt."@en;
     doap:programming-language "Java" ;
-    solid-test:origin <https://tester> ;
-    solid-test:maxThreads 8 ;
     solid-test:features "authentication", "acl", "wac-allow" .
 
 <ess>
@@ -38,8 +36,6 @@ prefix dcterms: <http://purl.org/dc/terms/>
     doap:homepage <https://inrupt.com/products/enterprise-solid-server>;
     doap:description "A production-grade Solid server produced and supported by Inrupt."@en;
     doap:programming-language "Java" ;
-    solid-test:origin <https://tester> ;
-    solid-test:maxThreads 8 ;
     solid-test:features "authentication", "wac-allow" .
 
 <css>
@@ -54,10 +50,7 @@ prefix dcterms: <http://purl.org/dc/terms/>
     doap:homepage <https://github.com/solid/community-server> ;
     doap:description "An open and modular implementation of the Solid specifications."@en ;
     doap:programming-language "TypeScript" ;
-    solid-test:origin <https://tester> ;
-    solid-test:maxThreads 8 ;
-    solid-test:features "authentication", "acl", "wac-allow" ;
-    solid-test:setupRootAcl false .
+    solid-test:features "authentication", "acl", "wac-allow" .
 
 <nss>
     a earl:Software, earl:TestSubject ;
@@ -71,8 +64,6 @@ prefix dcterms: <http://purl.org/dc/terms/>
     doap:homepage <https://github.com/solid/node-solid-server> ;
     doap:description "Solid server on top of the file-system in NodeJS."@en ;
     doap:programming-language "JavaScript" ;
-    solid-test:origin <https://tester> ;
-    solid-test:maxThreads 1 ;
     solid-test:features "authentication", "acl", "wac-allow" .
 
 #<trinpod>
@@ -87,6 +78,4 @@ prefix dcterms: <http://purl.org/dc/terms/>
 #    doap:homepage <https://graphmetrix.com/trinpod> ;
 #    doap:description "TrinPod™ is an Industrial strength Solid Pod with conceptual computing through Trinity AI Capable of handling a massive amount of data."@en ;
 #    doap:programming-language "Unknown" ;
-#    solid-test:origin <https://tester> ;
-#    solid-test:maxThreads 1 ;
 #    solid-test:features "authentication", "acl", "wac-allow" .

--- a/src/main/java/org/solid/testharness/Application.java
+++ b/src/main/java/org/solid/testharness/Application.java
@@ -58,6 +58,7 @@ public class Application implements QuarkusApplication {
     public static final String COVERAGE = "coverage";
     public static final String TESTS = "tests";
     public static final String FILTER = "filter";
+    public static final String SKIP_TEARDOWN = "skip-teardown";
 
     @Inject
     Config config;
@@ -71,6 +72,8 @@ public class Application implements QuarkusApplication {
         final Options options = new Options();
         options.addOption(Option.builder().longOpt(COVERAGE).desc("produce a coverage report").build());
         options.addOption(Option.builder().longOpt(TESTS).desc("produce test and coverage reports").build());
+        options.addOption(Option.builder().longOpt(SKIP_TEARDOWN)
+                .desc("skip teardown (when server itself is being stopped)").build());
         options.addOption(
                 Option.builder().longOpt(SUBJECTS).hasArg().desc("URL or path to test subject config (Turtle)").build()
         );
@@ -135,6 +138,10 @@ public class Application implements QuarkusApplication {
                                 .filter(s -> !StringUtils.isBlank(s))
                                 .collect(Collectors.toList());
                         logger.debug("Filters = {}", filters);
+                    }
+                    if (line.hasOption(SKIP_TEARDOWN)) {
+                        config.setSkipTearDown(true);
+                        logger.debug("Skip teardown = true");
                     }
                 }
 

--- a/src/main/java/org/solid/testharness/ConformanceTestHarness.java
+++ b/src/main/java/org/solid/testharness/ConformanceTestHarness.java
@@ -177,8 +177,7 @@ public class ConformanceTestHarness {
         }
 
         logger.info("===================== RUN TESTS ========================");
-        final TestSuiteResults results = testRunner.runTests(featurePaths,
-                testSubject.getTargetServer().getMaxThreads());
+        final TestSuiteResults results = testRunner.runTests(featurePaths, config.getMaxThreads());
         reportGenerator.setResults(results);
 
         if (!config.isSkipTearDown()) {

--- a/src/main/java/org/solid/testharness/ConformanceTestHarness.java
+++ b/src/main/java/org/solid/testharness/ConformanceTestHarness.java
@@ -165,6 +165,7 @@ public class ConformanceTestHarness {
             }
 
             logger.info("===================== REGISTER CLIENTS ========================");
+            logger.info("Test subject: {}", config.getServerRoot());
             if (config.getUserRegistrationEndpoint() != null) {
                 testSubject.registerUsers();
             }
@@ -180,8 +181,10 @@ public class ConformanceTestHarness {
                 testSubject.getTargetServer().getMaxThreads());
         reportGenerator.setResults(results);
 
-        logger.info("===================== DELETING TEST RESOURCES ========================");
-        testSubject.tearDownServer();
+        if (!config.isSkipTearDown()) {
+            logger.info("===================== DELETING TEST RESOURCES ========================");
+            testSubject.tearDownServer();
+        }
 
         logger.info("===================== BUILD REPORTS ========================");
         final File outputDir = config.getOutputDirectory();

--- a/src/main/java/org/solid/testharness/config/Config.java
+++ b/src/main/java/org/solid/testharness/config/Config.java
@@ -96,6 +96,8 @@ public class Config {
     @Inject
     PathMappings pathMappings;
 
+    private boolean skipTearDown;
+
     public IRI getTestSubject() {
         if (testSubject == null && target.isPresent()) {
             logger.debug("Use config to set target: {}", target.get());
@@ -233,5 +235,13 @@ public class Config {
             }
         }
         return null;
+    }
+
+    public void setSkipTearDown(final boolean skipTearDown) {
+        this.skipTearDown = skipTearDown;
+    }
+
+    public boolean isSkipTearDown() {
+        return skipTearDown;
     }
 }

--- a/src/main/java/org/solid/testharness/config/Config.java
+++ b/src/main/java/org/solid/testharness/config/Config.java
@@ -77,6 +77,12 @@ public class Config {
     Integer connectTimeout;
     @ConfigProperty(name = "readTimeout", defaultValue = "5000")
     Integer readTimeout;
+    @ConfigProperty(name = "maxThreads", defaultValue = "8")
+    Integer maxThreads;
+    @ConfigProperty(name = "origin", defaultValue = "https://tester")
+    String origin;
+    @ConfigProperty(name = "setupRootAcl", defaultValue = "false")
+    Boolean setupRootAcl;
 
     // properties normally found in environment variables or the .env file
     @ConfigProperty(name = "SOLID_IDENTITY_PROVIDER")
@@ -209,6 +215,26 @@ public class Config {
         return readTimeout;
     }
 
+    public Integer getMaxThreads() {
+        return maxThreads;
+    }
+
+    public String getOrigin() {
+        return origin;
+    }
+
+    public boolean isSetupRootAcl() {
+        return setupRootAcl;
+    }
+
+    public void setSkipTearDown(final boolean skipTearDown) {
+        this.skipTearDown = skipTearDown;
+    }
+
+    public boolean isSkipTearDown() {
+        return skipTearDown;
+    }
+
     public void logConfigSettings() {
         if (logger.isInfoEnabled()) {
             logger.info("Subjects URL:   {}", getSubjectsUrl().toString());
@@ -235,13 +261,5 @@ public class Config {
             }
         }
         return null;
-    }
-
-    public void setSkipTearDown(final boolean skipTearDown) {
-        this.skipTearDown = skipTearDown;
-    }
-
-    public boolean isSkipTearDown() {
-        return skipTearDown;
     }
 }

--- a/src/main/java/org/solid/testharness/config/TargetServer.java
+++ b/src/main/java/org/solid/testharness/config/TargetServer.java
@@ -28,9 +28,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.solid.common.vocab.SOLID_TEST;
 import org.solid.testharness.utils.DataModelBase;
-import org.solid.testharness.utils.TestHarnessInitializationException;
 
-import javax.validation.constraints.Positive;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -38,19 +36,10 @@ public class TargetServer extends DataModelBase {
     private static final Logger logger = LoggerFactory.getLogger(TargetServer.class);
 
     private Map<String, Boolean> features;
-    @Positive(message = "maxThreads must be >= 1")
-    private Integer maxThreads;
-    private String origin;
-    private Boolean setupRootAcl;
-    private Boolean disableDPoP;
 
-    public TargetServer(final IRI subject, final String origin, final Map<String, Boolean> features) {
+    public TargetServer(final IRI subject, final Map<String, Boolean> features) {
         super(subject, ConstructMode.DEEP);
-        this.origin = origin;
         this.features = features;
-        this.maxThreads = 8;
-        this.setupRootAcl = false;
-        this.disableDPoP = false;
     }
 
     public TargetServer(final IRI subject) {
@@ -58,33 +47,9 @@ public class TargetServer extends DataModelBase {
         logger.debug("Retrieved {} statements for {}", super.size(), subject);
         features = getLiteralsAsStringSet(SOLID_TEST.features).stream()
                 .collect(Collectors.toMap(Object::toString, f -> Boolean.TRUE));
-        maxThreads = getLiteralAsInt(SOLID_TEST.maxThreads);
-        if (maxThreads <= 0) {
-            throw new TestHarnessInitializationException("maxThreads must be >= 1");
-        }
-        origin = getIriAsString(SOLID_TEST.origin);
-        setupRootAcl = getLiteralAsBoolean(SOLID_TEST.setupRootAcl);
-        // TODO: Add disableDPoP to vocab
-        disableDPoP = false; //getLiteralAsBoolean(SOLID_TEST.disableDPoP);
     }
 
     public Map<String, Boolean> getFeatures() {
         return features;
-    }
-
-    public int getMaxThreads() {
-        return maxThreads;
-    }
-
-    public String getOrigin() {
-        return origin;
-    }
-
-    public boolean isSetupRootAcl() {
-        return setupRootAcl;
-    }
-
-    public boolean isDisableDPoP() {
-        return disableDPoP;
     }
 }

--- a/src/main/java/org/solid/testharness/config/TestSubject.java
+++ b/src/main/java/org/solid/testharness/config/TestSubject.java
@@ -91,7 +91,6 @@ public class TestSubject {
             targetServer = new TargetServer(testSubject);
             dataRepository.setTestSubject(testSubject);
             logger.debug("TestSubject {}", targetServer.getSubject());
-            logger.debug("Max threads: {}", targetServer.getMaxThreads());
         } catch (IOException e) {
             throw (TestHarnessInitializationException) new TestHarnessInitializationException(
                     "Failed to read config file %s: %s",
@@ -121,7 +120,7 @@ public class TestSubject {
             throw new TestHarnessInitializationException("No target server has been configured");
         }
         final SolidClient solidClient = new SolidClient(HttpConstants.ALICE);
-        if (targetServer.isSetupRootAcl()) {
+        if (config.isSetupRootAcl()) {
             logger.debug("Setup root acl");
             try {
                 final URI rootAclUrl = solidClient.getResourceAclLink(config.getServerRoot());

--- a/src/main/java/org/solid/testharness/http/AuthManager.java
+++ b/src/main/java/org/solid/testharness/http/AuthManager.java
@@ -96,10 +96,7 @@ public class AuthManager {
             authClient = clientRegistry.getClient(user);
         } else {
             logger.debug("Build new client for {}", user);
-            final Client.Builder builder = new Client.Builder(user);
-            if (!targetServer.isDisableDPoP()) {
-                builder.withDpopSupport();
-            }
+            final Client.Builder builder = new Client.Builder(user).withDpopSupport();
             if (config.overridingTrust()) {
                 builder.withLocalhostSupport();
             }
@@ -177,7 +174,7 @@ public class AuthManager {
             startLoginSession(client, userConfig, config.getLoginEndpoint());
         }
 
-        final String appOrigin = targetServer.getOrigin();
+        final String appOrigin = config.getOrigin();
         final Registration clientRegistration = registerClient(client, oidcConfig, appOrigin);
         final String clientId = clientRegistration.getClientId();
 

--- a/src/main/java/org/solid/testharness/http/AuthManager.java
+++ b/src/main/java/org/solid/testharness/http/AuthManager.java
@@ -63,7 +63,7 @@ public class AuthManager {
     ClientRegistry clientRegistry;
 
     public void registerUser(@NotNull final String user) throws Exception {
-        logger.info("Register user {}", user);
+        logger.info("Registering user {} at {}", user, config.getUserRegistrationEndpoint());
         final UserCredentials userConfig = config.getCredentials(user);
         final Client client = clientRegistry.getClient(ClientRegistry.DEFAULT);
 

--- a/src/test/java/org/solid/testharness/ApplicationTest.java
+++ b/src/test/java/org/solid/testharness/ApplicationTest.java
@@ -237,6 +237,14 @@ class ApplicationTest {
     void runTestSuitesNoResults() throws Exception {
         when(conformanceTestHarness.runTestSuites(any())).thenReturn(null);
         assertEquals(1, application.run("--tests"));
+        verify(config, never()).setSkipTearDown(true);
+    }
+
+    @Test
+    void runTestSuitesNoTearDown() throws Exception {
+        when(conformanceTestHarness.runTestSuites(any())).thenReturn(null);
+        assertEquals(1, application.run("--tests", "--skip-teardown"));
+        verify(config).setSkipTearDown(true);
     }
 
     @Test

--- a/src/test/java/org/solid/testharness/ConformanceTestHarnessTest.java
+++ b/src/test/java/org/solid/testharness/ConformanceTestHarnessTest.java
@@ -269,7 +269,6 @@ class ConformanceTestHarnessTest {
     private void mockTargetServer() {
         final TargetServer targetServer = mock(TargetServer.class);
         when(targetServer.getFeatures()).thenReturn(Map.of("feature", false));
-        when(targetServer.getMaxThreads()).thenReturn(1);
         when(testSubject.getTargetServer()).thenReturn(targetServer);
     }
 

--- a/src/test/java/org/solid/testharness/ConformanceTestHarnessTest.java
+++ b/src/test/java/org/solid/testharness/ConformanceTestHarnessTest.java
@@ -187,6 +187,20 @@ class ConformanceTestHarnessTest {
         when(testRunner.runTests(any(), anyInt())).thenReturn(results);
         assertEquals(1, conformanceTestHarness.runTestSuites().getFailCount());
         assertTrue(Files.exists(tmp.resolve("report.html")));
+        verify(testSubject).tearDownServer();
+    }
+
+    @Test
+    void runTestSuiteNoTearDown() {
+        mockTargetServer();
+        when(config.isSkipTearDown()).thenReturn(true);
+        when(testSuiteDescription.getSupportedTestCases(any())).thenReturn(Collections.emptyList());
+        when(testSuiteDescription.locateTestCases(any())).thenReturn(List.of("test"));
+        final TestSuiteResults results = mockResults(1);
+        when(testRunner.runTests(any(), anyInt())).thenReturn(results);
+        assertEquals(1, conformanceTestHarness.runTestSuites().getFailCount());
+        assertTrue(Files.exists(tmp.resolve("report.html")));
+        verify(testSubject, never()).tearDownServer();
     }
 
     @Test

--- a/src/test/java/org/solid/testharness/config/ConfigTest.java
+++ b/src/test/java/org/solid/testharness/config/ConfigTest.java
@@ -136,4 +136,10 @@ public class ConfigTest {
     void getReadTimeout() {
         assertEquals(1000, config.getReadTimeout());
     }
-}
+
+    @Test
+    void setSkipTearDown() {
+        assertFalse(config.isSkipTearDown());
+        config.setSkipTearDown(true);
+        assertTrue(config.isSkipTearDown());
+    }}

--- a/src/test/java/org/solid/testharness/config/ConfigTest.java
+++ b/src/test/java/org/solid/testharness/config/ConfigTest.java
@@ -36,6 +36,7 @@ import java.net.URI;
 
 import static org.eclipse.rdf4j.model.util.Values.iri;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @QuarkusTest
 @TestProfile(ConfigTestNormalProfile.class)
@@ -135,6 +136,21 @@ public class ConfigTest {
     @Test
     void getReadTimeout() {
         assertEquals(1000, config.getReadTimeout());
+    }
+
+    @Test
+    public void getMaxThreads() {
+        assertEquals(4, config.getMaxThreads());
+    }
+
+    @Test
+    public void getOrigin() {
+        assertEquals("https://testharness", config.getOrigin());
+    }
+
+    @Test
+    public void isSetupRootAcl() {
+        assertTrue(config.isSetupRootAcl());
     }
 
     @Test

--- a/src/test/java/org/solid/testharness/config/TargetServerTest.java
+++ b/src/test/java/org/solid/testharness/config/TargetServerTest.java
@@ -42,16 +42,12 @@ public class TargetServerTest {
     @Test
     public void constructor() {
         final TargetServer targetServer = new TargetServer(
-                iri("https://github.com/solid/conformance-test-harness/css"), "https://tester",
+                iri("https://github.com/solid/conformance-test-harness/css"),
                 Map.of("authentication", true, "acl", true, "wac-allow", true));
         assertAll("targetServer",
                 () -> assertNotNull(targetServer.getFeatures()),
                 () -> assertEquals(true, targetServer.getFeatures().get("authentication")),
-                () -> assertNull(targetServer.getFeatures().get("feature2")),
-                () -> assertEquals("https://tester", targetServer.getOrigin()),
-                () -> assertEquals(false, targetServer.isSetupRootAcl()),
-                () -> assertEquals(8, targetServer.getMaxThreads()),
-                () -> assertEquals(false, targetServer.isDisableDPoP())
+                () -> assertNull(targetServer.getFeatures().get("feature2"))
         );
     }
 
@@ -63,18 +59,7 @@ public class TargetServerTest {
         assertAll("targetServer",
                 () -> assertNotNull(targetServer.getFeatures()),
                 () -> assertEquals(true, targetServer.getFeatures().get("feature1")),
-                () -> assertNull(targetServer.getFeatures().get("feature2")),
-                () -> assertEquals("https://tester", targetServer.getOrigin()),
-                () -> assertEquals(true, targetServer.isSetupRootAcl()),
-                () -> assertEquals(4, targetServer.getMaxThreads()),
-                () -> assertEquals(false, targetServer.isDisableDPoP())
+                () -> assertNull(targetServer.getFeatures().get("feature2"))
         );
-    }
-
-    @Test
-    public void parseTargetServerWithBadThreads() throws Exception {
-        final URL testFile = TestUtils.getFileUrl("src/test/resources/config/targetserver-testing-feature.ttl");
-        TestData.insertData(dataRepository, testFile);
-        assertThrows(TestHarnessInitializationException.class, () -> new TargetServer(iri(TestData.SAMPLE_NS, "bad")));
     }
 }

--- a/src/test/java/org/solid/testharness/config/TestSubjectTest.java
+++ b/src/test/java/org/solid/testharness/config/TestSubjectTest.java
@@ -71,7 +71,7 @@ public class TestSubjectTest {
     void prepareServerNoRootAcl() throws Exception {
         final TargetServer targetServer = mock(TargetServer.class);
         testSubject.setTargetServer(targetServer);
-        when(targetServer.isSetupRootAcl()).thenReturn(false);
+        when(config.isSetupRootAcl()).thenReturn(false);
         when(config.getTestContainer()).thenReturn("https://server/test/");
         when(config.getReadTimeout()).thenReturn(5000);
         when(config.getAgent()).thenReturn("AGENT");
@@ -93,7 +93,7 @@ public class TestSubjectTest {
     void prepareServerNoRootAclThrows() throws Exception {
         final TargetServer targetServer = mock(TargetServer.class);
         testSubject.setTargetServer(targetServer);
-        when(targetServer.isSetupRootAcl()).thenReturn(false);
+        when(config.isSetupRootAcl()).thenReturn(false);
         when(config.getTestContainer()).thenReturn("https://server/test/");
         when(config.getReadTimeout()).thenReturn(5000);
         when(config.getAgent()).thenReturn("AGENT");
@@ -113,7 +113,7 @@ public class TestSubjectTest {
     void prepareServerWithRootAcl() throws IOException, InterruptedException {
         final TargetServer targetServer = mock(TargetServer.class);
         testSubject.setTargetServer(targetServer);
-        when(targetServer.isSetupRootAcl()).thenReturn(true);
+        when(config.isSetupRootAcl()).thenReturn(true);
         when(config.getWebIds())
                 .thenReturn(Map.of(HttpConstants.ALICE, "https://alice.target.example.org/profile/card#me"));
         when(config.getTestContainer()).thenReturn("https://server/test/");
@@ -149,7 +149,7 @@ public class TestSubjectTest {
     void prepareServerWithRootAclThrows() throws IOException, InterruptedException {
         final TargetServer targetServer = mock(TargetServer.class);
         testSubject.setTargetServer(targetServer);
-        when(targetServer.isSetupRootAcl()).thenReturn(true);
+        when(config.isSetupRootAcl()).thenReturn(true);
         when(config.getWebIds())
                 .thenReturn(Map.of(HttpConstants.ALICE, "https://alice.target.example.org/profile/card#me"));
         when(config.getTestContainer()).thenReturn("https://server/test/");
@@ -174,7 +174,7 @@ public class TestSubjectTest {
     void prepareServerWithRootAclNoLink() throws IOException, InterruptedException {
         final TargetServer targetServer = mock(TargetServer.class);
         testSubject.setTargetServer(targetServer);
-        when(targetServer.isSetupRootAcl()).thenReturn(true);
+        when(config.isSetupRootAcl()).thenReturn(true);
         when(config.getWebIds())
                 .thenReturn(Map.of(HttpConstants.ALICE, "https://alice.target.example.org/profile/card#me"));
         when(config.getTestContainer()).thenReturn("https://server/test/");
@@ -197,7 +197,7 @@ public class TestSubjectTest {
     void prepareServerWithRootAclFails() throws IOException, InterruptedException {
         final TargetServer targetServer = mock(TargetServer.class);
         testSubject.setTargetServer(targetServer);
-        when(targetServer.isSetupRootAcl()).thenReturn(true);
+        when(config.isSetupRootAcl()).thenReturn(true);
         when(config.getWebIds())
                 .thenReturn(Map.of(HttpConstants.ALICE, "https://alice.target.example.org/profile/card#me"));
         when(config.getTestContainer()).thenReturn("https://server/test/");
@@ -287,9 +287,9 @@ public class TestSubjectTest {
     @Test
     void setTargetServer() {
         final TargetServer targetServer = mock(TargetServer.class);
-        when(targetServer.getOrigin()).thenReturn("http://test");
+        when(targetServer.getFeatures()).thenReturn(Map.of("feature1", true));
         testSubject.setTargetServer(targetServer);
-        assertEquals("http://test", testSubject.getTargetServer().getOrigin());
+        assertTrue(testSubject.getTargetServer().getFeatures().get("feature1"));
     }
 
     @Test

--- a/src/test/java/org/solid/testharness/reporting/ReportFragmentTest.java
+++ b/src/test/java/org/solid/testharness/reporting/ReportFragmentTest.java
@@ -235,8 +235,6 @@ class ReportFragmentTest {
         final IRI testSubjectIri = iri("https://github.com/solid/conformance-test-harness/testserver");
         final TestSubject testSubject = new TestSubject(testSubjectIri);
         testSubject.getModel().remove(null, SOLID_TEST.features, null);
-        testSubject.getModel().remove(null, SOLID_TEST.maxThreads, null);
-        testSubject.getModel().remove(null, SOLID_TEST.origin, null);
         logger.debug("TestSubject Model:\n{}", TestUtils.toTurtle(testSubject.getModel()));
 
         final String report = render("testSubject", testSubject);

--- a/src/test/java/org/solid/testharness/reporting/ReportGeneratorTest.java
+++ b/src/test/java/org/solid/testharness/reporting/ReportGeneratorTest.java
@@ -119,8 +119,6 @@ class ReportGeneratorTest {
         try (RepositoryConnection conn = dataRepository.getConnection()) {
             resultModel = QueryResults.asModel(conn.getStatements(null, null, null));
             resultModel.remove(null, SOLID_TEST.features, null);
-            resultModel.remove(null, SOLID_TEST.maxThreads, null);
-            resultModel.remove(null, SOLID_TEST.origin, null);
             final Value bnode = resultModel.getStatements(
                     iri("https://github.com/solid/conformance-test-harness/testserver2"),
                     DOAP.release, null

--- a/src/test/java/org/solid/testharness/utils/DataRepositoryTest.java
+++ b/src/test/java/org/solid/testharness/utils/DataRepositoryTest.java
@@ -255,7 +255,7 @@ class DataRepositoryTest {
         final DataRepository dataRepository = new DataRepository();
         final URL url = Path.of("src/test/resources/config/config-sample.ttl").normalize().toUri().toURL();
         dataRepository.load(url);
-        assertEquals(33, dataRepositorySize(dataRepository));
+        assertEquals(28, dataRepositorySize(dataRepository));
     }
 
     @Test

--- a/src/test/java/org/solid/testharness2/config/ConfigMissingTest.java
+++ b/src/test/java/org/solid/testharness2/config/ConfigMissingTest.java
@@ -83,4 +83,18 @@ public class ConfigMissingTest {
     void getReadTimeout() {
         assertEquals(5000, config.getReadTimeout());
     }
-}
+
+    @Test
+    public void getMaxThreads() {
+        assertEquals(8, config.getMaxThreads());
+    }
+
+    @Test
+    public void getOrigin() {
+        assertEquals("https://tester", config.getOrigin());
+    }
+
+    @Test
+    public void isSetupRootAcl() {
+        assertFalse(config.isSetupRootAcl());
+    }}

--- a/src/test/resources/config/config-sample-bad.ttl
+++ b/src/test/resources/config/config-sample-bad.ttl
@@ -10,6 +10,4 @@ prefix solid: <http://www.w3.org/ns/solid/terms#>
 
 <example>
     a earl:Software, earl:TestSubject ;
-    doap:name "Example server" ;
-    solid-test:maxThreads 8 ;
-    solid-test:setupRootAcl true .
+    doap:name "Example server" .

--- a/src/test/resources/config/config-sample-single.ttl
+++ b/src/test/resources/config/config-sample-single.ttl
@@ -20,6 +20,4 @@ prefix solid: <http://www.w3.org/ns/solid/terms#>
     doap:homepage <https://inrupt.com/products/enterprise-solid-server>;
     doap:description "A production-grade Solid server produced and supported by Inrupt.";
     doap:programming-language "Java" ;
-    solid-test:origin <https://tester> ;
-    solid-test:maxThreads 4 ;
     solid-test:features "authentication", "acl", "wac-allow" .

--- a/src/test/resources/config/config-sample.ttl
+++ b/src/test/resources/config/config-sample.ttl
@@ -20,8 +20,6 @@
     doap:homepage <https://inrupt.com/products/enterprise-solid-server>;
     doap:description "A production-grade Solid server produced and supported by Inrupt.";
     doap:programming-language "Java" ;
-    solid-test:origin <https://tester> ;
-    solid-test:maxThreads 4 ;
     solid-test:features "authentication", "acl", "wac-allow" .
 
 <testserver2>
@@ -36,7 +34,4 @@
     doap:homepage <https://github.com/solid/community-server> ;
     doap:description "An open and modular implementation of the Solid specifications." ;
     doap:programming-language "TypeScript" ;
-    solid-test:origin <https://tester> ;
-    solid-test:maxThreads 8 ;
-    solid-test:features "authentication", "acl", "wac-allow" ;
-    solid-test:setupRootAcl true .
+    solid-test:features "authentication", "acl", "wac-allow" .

--- a/src/test/resources/config/targetserver-testing-feature.ttl
+++ b/src/test/resources/config/targetserver-testing-feature.ttl
@@ -17,11 +17,7 @@ ex:testserver
     doap:homepage <https://inrupt.com/products/enterprise-solid-server>;
     doap:description "A production-grade Solid server produced and supported by Inrupt.";
     doap:programming-language "Java" ;
-    solid-test:origin <https://tester> ;
-    solid-test:maxThreads 4 ;
-    solid-test:features "feature1" ;
-#    solid-test:disableDPoP true ;
-    solid-test:setupRootAcl true .
+    solid-test:features "feature1" .
 
 ex:bad a earl:Software, earl:TestSubject .
 


### PR DESCRIPTION
Add option to skip teardown if test server is in a temporary container.
Move config for maxThreads, origin and setupRootAcl to environment instead of test subject description.