### PR TITLE
Universal access control - preparatory work

### DIFF
--- a/config/application.yaml
+++ b/config/application.yaml
@@ -7,9 +7,9 @@
     - https://github.com/solid/conformance-test-harness/example/protocol/solid-protocol-spec.ttl
     - https://github.com/solid/conformance-test-harness/example/web-access-control/web-access-control-spec.ttl
   target: https://github.com/solid/conformance-test-harness/ess-compat
-  #target: https://github.com/solid/conformance-test-harness/ess
-  #target: https://github.com/solid/conformance-test-harness/css
-  #target: https://github.com/solid/conformance-test-harness/nss
+#  target: https://github.com/solid/conformance-test-harness/ess
+#  target: https://github.com/solid/conformance-test-harness/css
+#  target: https://github.com/solid/conformance-test-harness/nss
 #  target: https://github.com/solid/conformance-test-harness/trinpod
 
   # mapping feature URIs

--- a/example/protocol/wac-allow/access-Bob-W-public-RA.feature
+++ b/example/protocol/wac-allow/access-Bob-W-public-RA.feature
@@ -12,7 +12,7 @@ Feature: The WAC-Allow header shows user and public access modes with Bob write 
             + createBobAccessToAuthorization(webIds.bob, resource.getUrl(), 'acl:Write')
             + createPublicAccessToAuthorization(resource.getUrl(), 'acl:Read, acl:Append')
           karate.log('ACL: ' + acl);
-          resource.setAcl(acl);
+          resource.setAccessDataset(acl);
         }
         return resource;
       }

--- a/example/protocol/wac-allow/access-public-R.feature
+++ b/example/protocol/wac-allow/access-public-R.feature
@@ -11,7 +11,7 @@ Feature: The WAC-Allow header shows user and public access modes with public rea
             + createOwnerAuthorization(webIds.alice, resource.getUrl())
             + createPublicAccessToAuthorization(resource.getUrl(), 'acl:Read');
           karate.log('ACL: ' + acl);
-          resource.setAcl(acl);
+          resource.setAccessDataset(acl);
         }
         return resource;
       }

--- a/example/protocol/wac-allow/default-Bob-W-public-RA.feature
+++ b/example/protocol/wac-allow/default-Bob-W-public-RA.feature
@@ -12,7 +12,7 @@ Feature: The WAC-Allow header shows user and public access modes with Bob write 
             + createBobDefaultAuthorization(webIds.bob, resource.getContainer().getUrl(), 'acl:Write')
             + createPublicDefaultAuthorization(resource.getContainer().getUrl(), 'acl:Read, acl:Append')
           karate.log('ACL: ' + acl);
-          resource.getContainer().setAcl(acl)
+          resource.getContainer().setAccessDataset(acl)
         }
         return resource;
       }

--- a/example/web-access-control/protected-operation/not-read-resource-access-AWC.feature
+++ b/example/web-access-control/protected-operation/not-read-resource-access-AWC.feature
@@ -11,7 +11,7 @@ Feature: Bob cannot read an RDF resource to which he is not granted read access
             + createOwnerAuthorization(webIds.alice, resource.getUrl())
             + createBobAccessToAuthorization(webIds.bob, resource.getUrl(), 'acl:Append, acl:Write, acl:Control')
           karate.log('ACL: ' + acl);
-          resource.setAcl(acl);
+          resource.setAccessDataset(acl);
         }
         return resource;
       }

--- a/example/web-access-control/protected-operation/not-read-resource-default-AWC.feature
+++ b/example/web-access-control/protected-operation/not-read-resource-default-AWC.feature
@@ -11,7 +11,7 @@ Feature: Bob cannot read an RDF resource to which he is not granted default read
             + createOwnerAuthorization(webIds.alice, resource.getContainer().getUrl())
             + createBobDefaultAuthorization(webIds.bob, resource.getContainer().getUrl(), 'acl:Append, acl:Write, acl:Control')
           karate.log('ACL: ' + acl);
-          resource.getContainer().setAcl(acl);
+          resource.getContainer().setAccessDataset(acl);
         }
         return resource;
       }

--- a/example/web-access-control/protected-operation/read-resource-access-R.feature
+++ b/example/web-access-control/protected-operation/read-resource-access-R.feature
@@ -11,7 +11,7 @@ Feature: Bob can only read an RDF resource to which he is only granted read acce
             + createOwnerAuthorization(webIds.alice, resource.getUrl())
             + createBobAccessToAuthorization(webIds.bob, resource.getUrl(), 'acl:Read')
           karate.log('ACL: ' + acl);
-          resource.setAcl(acl);
+          resource.setAccessDataset(acl);
         }
         return resource;
       }

--- a/example/web-access-control/protected-operation/read-resource-default-R.feature
+++ b/example/web-access-control/protected-operation/read-resource-default-R.feature
@@ -11,7 +11,7 @@ Feature: Bob can only read an RDF resource to which he is only granted default r
             + createOwnerAuthorization(webIds.alice, resource.getContainer().getUrl())
             + createBobDefaultAuthorization(webIds.bob, resource.getContainer().getUrl(), 'acl:Read')
           karate.log('ACL: ' + acl);
-          resource.getContainer().setAcl(acl);
+          resource.getContainer().setAccessDataset(acl);
         }
         return resource;
       }

--- a/src/main/java/org/solid/testharness/TestRunner.java
+++ b/src/main/java/org/solid/testharness/TestRunner.java
@@ -25,7 +25,6 @@ package org.solid.testharness;
 
 import com.intuit.karate.Results;
 import com.intuit.karate.Runner;
-import org.apache.commons.lang3.StringUtils;
 import org.solid.testharness.reporting.TestSuiteResults;
 import org.solid.testharness.utils.FeatureResultHandler;
 
@@ -40,7 +39,8 @@ public class TestRunner {
 
     @SuppressWarnings("unchecked")
     // Unavoidable as Runner.builder().path() takes a list or vararg of Strings
-    public TestSuiteResults runTests(final List<String> featurePaths, final int threads) {
+    public TestSuiteResults runTests(final List<String> featurePaths, final int threads,
+                                     final boolean enableReporting) {
         // we can also create Features which may be useful when fetching from remote resource although this may cause
         // problems with loading other features files due to classpath issues - Karate may need a RemoteResource type
         // that knows how to fetch related resources from the same URL the feature came from
@@ -53,23 +53,13 @@ public class TestRunner {
 //                .outputHtmlReport(true)
 //                .parallel(8);
 
-        final Results results = Runner.builder()
+        Runner.Builder builder = Runner.builder()
                 .path(featurePaths)
-                .tags("~@ignore")
-                .outputHtmlReport(true)
-                .suiteReports(featureResultHandler)
-                .parallel(threads);
-        return new TestSuiteResults(results);
-    }
-
-    public TestSuiteResults runTest(final String featurePath) {
-        if (StringUtils.isBlank(featurePath)) {
-            throw new IllegalArgumentException("featurePath is a required parameter");
+                .tags("~@ignore");
+        if (enableReporting) {
+            builder = builder.outputHtmlReport(true).suiteReports(featureResultHandler);
         }
-        final Results results = Runner.builder()
-                .path(featurePath)
-                .tags("~@ignore")
-                .parallel(1);
+        final Results results = builder.parallel(threads);
         return new TestSuiteResults(results);
     }
 }

--- a/src/main/java/org/solid/testharness/config/Bootstrap.java
+++ b/src/main/java/org/solid/testharness/config/Bootstrap.java
@@ -26,6 +26,7 @@ package org.solid.testharness.config;
 import io.quarkus.runtime.Application;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.solid.testharness.ConformanceTestHarness;
 
 import javax.enterprise.inject.spi.CDI;
 
@@ -63,6 +64,10 @@ public final class Bootstrap {
 
     public TestSubject getTestSubject() {
         return CDI.current().select(TestSubject.class).get();
+    }
+
+    public ConformanceTestHarness getTestHarness() {
+        return CDI.current().select(ConformanceTestHarness.class).get();
     }
 
     public Config getConfig() {

--- a/src/main/java/org/solid/testharness/config/TestSubject.java
+++ b/src/main/java/org/solid/testharness/config/TestSubject.java
@@ -123,7 +123,7 @@ public class TestSubject {
         if (config.isSetupRootAcl()) {
             logger.debug("Setup root acl");
             try {
-                final URI rootAclUrl = solidClient.getResourceAclLink(config.getServerRoot());
+                final URI rootAclUrl = solidClient.getAclUri(config.getServerRoot());
                 if (rootAclUrl == null) {
                     throw new TestHarnessInitializationException("Failed getting the root ACL link");
                 }
@@ -146,13 +146,13 @@ public class TestSubject {
         try {
             final SolidContainer rootContainer = SolidContainer.create(solidClient, config.getTestContainer());
             logger.debug("Root container content: {}", rootContainer.getContentAsTurtle());
-            logger.debug("Root container access controls: {}", rootContainer.getAccessControls());
+            logger.debug("Root container access controls: {}", rootContainer.getAccessDataset());
 
             // create a root container for all the test cases
             rootTestContainer = SolidContainer.create(solidClient, config.getTestContainer())
                     .generateChildContainer().instantiate();
             logger.debug("Test container content: {}", rootTestContainer.getContentAsTurtle());
-            logger.debug("Test container access controls: {}", rootTestContainer.getAccessControls());
+            logger.debug("Test container access controls: {}", rootTestContainer.getAccessDataset());
         } catch (Exception e) {
             throw (TestHarnessInitializationException) new TestHarnessInitializationException(
                     "Failed to prepare server: %s", e.toString()

--- a/src/main/java/org/solid/testharness/http/AuthManager.java
+++ b/src/main/java/org/solid/testharness/http/AuthManager.java
@@ -28,7 +28,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.solid.testharness.config.Config;
-import org.solid.testharness.config.TargetServer;
 import org.solid.testharness.config.UserCredentials;
 import org.solid.testharness.utils.TestHarnessInitializationException;
 
@@ -84,11 +83,10 @@ public class AuthManager {
         }
     }
 
-    public SolidClient authenticate(@NotNull final String user, @NotNull final TargetServer targetServer)
+    public SolidClient authenticate(@NotNull final String user, final boolean authRequired)
             throws Exception {
         requireNonNull(user, "user must not be null");
-        requireNonNull(targetServer, "targetServer must not be null");
-        if (!targetServer.getFeatures().getOrDefault("authentication", false)) {
+        if (!authRequired) {
             return new SolidClient();
         }
         final Client authClient;

--- a/src/main/java/org/solid/testharness/http/SolidClient.java
+++ b/src/main/java/org/solid/testharness/http/SolidClient.java
@@ -102,14 +102,16 @@ public class SolidClient {
         return response;
     }
 
-    public URI getResourceAclLink(final URI uri) throws IOException, InterruptedException {
+    public URI getAclUri(final URI uri) throws IOException, InterruptedException {
         final HttpResponse<Void> response = client.head(uri);
-        return getAclLink(response.headers());
+        return getAclUri(response.headers());
     }
 
-    public URI getAclLink(final HttpHeaders headers) {
+    public URI getAclUri(final HttpHeaders headers) {
         final List<Link> links = HttpUtils.parseLinkHeaders(headers);
-        final Optional<Link> aclLink = links.stream().filter(link -> link.getRels().contains("acl")).findFirst();
+        final Optional<Link> aclLink = links.stream()
+                .filter(link -> link.getRels().contains("acl") ||
+                        link.getRels().contains("http://www.w3.org/ns/solid/acp#accessControl")).findFirst();
         return aclLink.map(Link::getUri).orElse(null);
     }
 

--- a/src/main/java/org/solid/testharness/utils/SolidResource.java
+++ b/src/main/java/org/solid/testharness/utils/SolidResource.java
@@ -38,7 +38,7 @@ public class SolidResource {
     protected SolidClient solidClient;
     protected URI url;
     private URI aclUrl;
-    private Boolean aclAvailable;
+    private Boolean aclLinkAvailable;
     private boolean containerType;
 
     public SolidResource(final SolidClient solidClient, final String url) {
@@ -63,11 +63,11 @@ public class SolidResource {
             try {
                 headers = solidClient.createResource(resourceUri, body, type);
                 if (headers != null && headers.allValues(HttpConstants.HEADER_LINK).size() != 0) {
-                    final URI aclLink = solidClient.getAclLink(headers);
+                    final URI aclLink = solidClient.getAclUri(headers);
                     if (aclLink != null) {
                         logger.debug("ACL LINK {}", aclLink);
                         aclUrl = resourceUri.resolve(aclLink);
-                        aclAvailable = true;
+                        aclLinkAvailable = true;
                     }
                 }
             } catch (Exception e) {
@@ -88,8 +88,8 @@ public class SolidResource {
         return url != null;
     }
 
-    public boolean setAcl(final String acl) throws Exception {
-        if (Boolean.FALSE.equals(aclAvailable)) return false;
+    public boolean setAccessDataset(final String acl) throws Exception {
+        if (Boolean.FALSE.equals(aclLinkAvailable)) return false;
         final String url = getAclUrl();
         if (url == null) return false;
         return solidClient.createAcl(URI.create(url), acl);
@@ -121,12 +121,12 @@ public class SolidResource {
     }
 
     public String getAclUrl() throws Exception {
-        if (aclUrl == null && !Boolean.FALSE.equals(aclAvailable)) {
-            final URI aclLink = solidClient.getResourceAclLink(url);
+        if (aclUrl == null && !Boolean.FALSE.equals(aclLinkAvailable)) {
+            final URI aclLink = solidClient.getAclUri(url);
             if (aclLink != null) {
                 aclUrl = url.resolve(aclLink);
             }
-            aclAvailable = aclLink != null;
+            aclLinkAvailable = aclLink != null;
         }
         return aclUrl != null ? aclUrl.toString() : null;
     }
@@ -135,7 +135,7 @@ public class SolidResource {
         return url != null ? solidClient.getContentAsTurtle(url) : "";
     }
 
-    public String getAccessControls() throws Exception {
+    public String getAccessDataset() throws Exception {
         return getAclUrl() != null ? solidClient.getAcl(aclUrl) : "";
     }
 

--- a/src/main/resources/karate-base.js
+++ b/src/main/resources/karate-base.js
@@ -7,6 +7,7 @@ function fn() {
     }
 
     const config = bootstrap.getConfig();
+    const testHarness = bootstrap.getTestHarness();
     const testSubject = bootstrap.getTestSubject();
     const target = testSubject.targetServer;
     if (target == null) {
@@ -24,7 +25,7 @@ function fn() {
         target,
         rootTestContainer: testSubject.getRootTestContainer(),
         ...additionalConfig,
-        clients: karate.toMap(testSubject.clients),
+        clients: karate.toMap(testHarness.clients),
         webIds: config.webIds
     };
 }

--- a/src/main/resources/setup.js
+++ b/src/main/resources/setup.js
@@ -9,12 +9,6 @@ function() {
         parseWacAllowHeader: (headers) => Java.type('org.solid.testharness.http.HttpUtils').parseWacAllowHeader(headers),
         createTestContainer: () => rootTestContainer.generateChildContainer(),
         createTestContainerImmediate: () => rootTestContainer.generateChildContainer().instantiate(),
-        createOwnerAuthorization: (ownerAgent, targetUri) => `
-<#owner> a acl:Authorization;
-  acl:agent <${ownerAgent}>;
-  acl:accessTo <${targetUri}>;
-  acl:default <${targetUri}>;
-  acl:mode acl:Read, acl:Write, acl:Control.`,
         createAuthorization: (config) => {
             // config: { authUri, agents, groups, publicAccess, authenticatedAccess, accessToTargets, defaultTargets, modes }
             let acl = `\n<${config.authUri}> a acl:Authorization;`
@@ -30,6 +24,7 @@ function() {
                     acl += config.groups.map((group) => `\n  acl:agentGroup <${group}>;`)
                 } else {
                     acl += `\n  acl:agentGroup <${config.groups}>;`
+                    // TODO: WHERE ARE GROUP DEFINITIONS
                 }
             }
             if (config.publicAccess) {
@@ -60,6 +55,13 @@ function() {
             return acl
         },
         aclPrefix: '@prefix acl: <http://www.w3.org/ns/auth/acl#>.\n@prefix foaf: <http://xmlns.com/foaf/0.1/>.',
+        createOwnerAuthorization: (ownerAgent, targetUri) => createAuthorization({
+            authUri: '#owner',
+            agents: ownerAgent,
+            accessToTargets: targetUri,
+            defaultTargets: targetUri,
+            modes: 'acl:Read, acl:Write, acl:Control'
+        }),
         createBobAccessToAuthorization: (webID, resourceUri, modes) => createAuthorization({
             authUri: '#bobAccessTo',
             agents: webID,

--- a/src/test/java/TestScenarioRunner.java
+++ b/src/test/java/TestScenarioRunner.java
@@ -25,33 +25,28 @@
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.solid.testharness.TestRunner;
-import org.solid.testharness.config.TestSubject;
+import org.solid.testharness.ConformanceTestHarness;
 import org.solid.testharness.reporting.TestSuiteResults;
 
 import javax.inject.Inject;
 import java.nio.file.Path;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @Tag("solid")
 @QuarkusTest
 public class TestScenarioRunner {
     @Inject
-    TestSubject testSubject;
-    @Inject
-    TestRunner testRunner;
+    ConformanceTestHarness conformanceTestHarness;
 
     @Test
     void testScenario() {
-        testSubject.loadTestSubjectConfig();
-        testSubject.registerClients();
-        testSubject.prepareServer();
-        final String featurePath = "example/content-negotiation/content-negotiation-turtle.feature";
+//        final String featurePath = "example/protocol/content-negotiation/content-negotiation-turtle.feature";
 //        final String featurePath = "example/writing-resource/containment.feature";
+        final String featurePath = "example/acp.feature";
         final String uri = Path.of(featurePath).toAbsolutePath().normalize().toUri().toString();
-        final TestSuiteResults results = testRunner.runTest(uri);
-        testSubject.tearDownServer();
+        final TestSuiteResults results = conformanceTestHarness.runSingleTest(uri);
         assertNotNull(results);
         assertEquals(0, results.getFailCount(), results.getErrorMessages());
     }

--- a/src/test/java/org/solid/testharness/TestRunnerTest.java
+++ b/src/test/java/org/solid/testharness/TestRunnerTest.java
@@ -24,73 +24,67 @@
 package org.solid.testharness;
 
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.mockito.InjectSpy;
 import org.junit.jupiter.api.Test;
 import org.solid.testharness.reporting.TestSuiteResults;
+import org.solid.testharness.utils.FeatureResultHandler;
 
 import javax.inject.Inject;
 import java.util.Collections;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 @QuarkusTest
 class TestRunnerTest {
 
     @Inject
     TestRunner testRunner;
+    @InjectSpy
+    FeatureResultHandler featureResultHandler;
+
 
     @Test
     void runTests() {
-        final TestSuiteResults results = testRunner.runTests(List.of("src/test/resources/test.feature"), 1);
+        final TestSuiteResults results = testRunner.runTests(List.of("src/test/resources/test.feature"), 1, true);
         assertNotNull(results);
         assertEquals(1, results.getFailCount());
     }
 
     @Test
     void runTestsEmpty() {
-        final TestSuiteResults results = testRunner.runTests(Collections.emptyList(), 10);
+        final TestSuiteResults results = testRunner.runTests(Collections.emptyList(), 10, true);
         assertNotNull(results);
         assertEquals(0, results.getFailCount());
     }
 
     @Test
     void runTestsNoThreads() {
-        final TestSuiteResults results = testRunner.runTests(Collections.emptyList(), 0);
+        final TestSuiteResults results = testRunner.runTests(Collections.emptyList(), 0, true);
         assertNotNull(results);
         assertEquals(0, results.getFailCount());
     }
 
     @Test
     void runTestsNoList() {
-        final TestSuiteResults results = testRunner.runTests(null, 1);
+        final TestSuiteResults results = testRunner.runTests(null, 1, true);
         assertNotNull(results);
         assertEquals(0, results.getFailCount());
     }
 
     @Test
     void runTestsMissing() {
-        assertThrows(RuntimeException.class, () -> testRunner.runTests(List.of("missing.feature"), 1));
+        assertThrows(RuntimeException.class, () -> testRunner.runTests(List.of("missing.feature"), 1, true));
     }
 
     @Test
-    void runTest() {
-        final TestSuiteResults results = testRunner.runTest("src/test/resources/test.feature");
+    void runTestNoReporting() {
+        final TestSuiteResults results = testRunner.runTests(List.of("src/test/resources/test.feature"), 1, false);
         assertNotNull(results);
         assertEquals(1, results.getFailCount());
-    }
-
-    @Test
-    void runTestEmpty() {
-        assertThrows(IllegalArgumentException.class, () -> testRunner.runTest(null));
-    }
-
-    @Test
-    void runTestBlank() {
-        assertThrows(IllegalArgumentException.class, () -> testRunner.runTest(""));
-    }
-
-    @Test
-    void runTestMissing() {
-        assertThrows(RuntimeException.class, () -> testRunner.runTest("missing.feature"));
+        verify(featureResultHandler, never()).featureReport(any(), any());
     }
 }

--- a/src/test/java/org/solid/testharness/config/BootstrapQuarkusTest.java
+++ b/src/test/java/org/solid/testharness/config/BootstrapQuarkusTest.java
@@ -48,6 +48,12 @@ class BootstrapQuarkusTest {
     }
 
     @Test
+    void getTestHarness() {
+        final Bootstrap bootstrap = Bootstrap.getInstance();
+        assertNotNull(bootstrap.getTestHarness());
+    }
+
+    @Test
     void getConfig() {
         final Bootstrap bootstrap = Bootstrap.getInstance();
         assertNotNull(bootstrap.getConfig());

--- a/src/test/java/org/solid/testharness/config/TestSubjectTest.java
+++ b/src/test/java/org/solid/testharness/config/TestSubjectTest.java
@@ -221,50 +221,6 @@ public class TestSubjectTest {
     }
 
     @Test
-    void registerUsers() throws Exception {
-        testSubject.registerUsers();
-        verify(authManager).registerUser(HttpConstants.ALICE);
-        verify(authManager).registerUser(HttpConstants.BOB);
-    }
-
-    @Test
-    void registerUsersException() throws Exception {
-        doThrow(new Exception("FAIL")).when(authManager).registerUser(any());
-        assertThrows(TestHarnessInitializationException.class, () -> testSubject.registerUsers());
-    }
-
-    @Test
-    void registerWithoutServer() {
-        testSubject.setTargetServer(null);
-        assertThrows(TestHarnessInitializationException.class, () -> testSubject.registerClients());
-    }
-
-    @Test
-    void registerClientsAndGet() throws Exception {
-        final TargetServer targetServer = mock(TargetServer.class);
-        testSubject.setTargetServer(targetServer);
-        when(config.getWebIds())
-                .thenReturn(Map.of(HttpConstants.ALICE, "https://alice.target.example.org/profile/card#me"));
-        final Client mockClient = mock(Client.class);
-        when(authManager.authenticate(anyString(), any(TargetServer.class))).thenReturn(new SolidClient(mockClient));
-        testSubject.registerClients();
-        final Map<String, SolidClient> clients = testSubject.getClients();
-        assertNotNull(clients);
-        assertEquals(1, clients.size());
-    }
-
-    @Test
-    void registerClientsWithAuthException() throws Exception {
-        final TargetServer targetServer = mock(TargetServer.class);
-        testSubject.setTargetServer(targetServer);
-        when(config.getWebIds())
-                .thenReturn(Map.of(HttpConstants.ALICE, "https://alice.target.example.org/profile/card#me"));
-        when(authManager.authenticate(anyString(), any(TargetServer.class)))
-                .thenThrow(new Exception("Failed as expected"));
-        assertThrows(TestHarnessInitializationException.class, () -> testSubject.registerClients());
-    }
-
-    @Test
     void loadTestSubjectConfigTarget1() throws MalformedURLException {
         when(config.getSubjectsUrl()).thenReturn(TestUtils.getFileUrl("src/test/resources/config/config-sample.ttl"));
         when(config.getTestSubject()).thenReturn(iri("https://github.com/solid/conformance-test-harness/testserver"));
@@ -300,11 +256,6 @@ public class TestSubjectTest {
         final TargetServer targetServer = testSubject.getTargetServer();
         assertNotNull(targetServer);
         assertEquals("https://github.com/solid/conformance-test-harness/default", targetServer.getSubject());
-    }
-
-    @Test
-    void getClientsNull() throws Exception {
-        assertNull(testSubject.getClients());
     }
 
     @Test

--- a/src/test/java/org/solid/testharness/http/AuthManagerTest.java
+++ b/src/test/java/org/solid/testharness/http/AuthManagerTest.java
@@ -29,15 +29,14 @@ import io.quarkus.test.junit.mockito.InjectMock;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import org.solid.testharness.config.*;
+import org.solid.testharness.config.Config;
+import org.solid.testharness.config.TestCredentials;
 import org.solid.testharness.utils.TestData;
 import org.solid.testharness.utils.TestHarnessInitializationException;
 
 import javax.inject.Inject;
 import javax.validation.ConstraintViolationException;
 import java.net.URI;
-import java.util.Collections;
-import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -83,43 +82,33 @@ class AuthManagerTest {
 
     @Test
     void authenticateNullUser() {
-        final TargetServer targetServer = mock(TargetServer.class);
-        assertThrows(ConstraintViolationException.class, () -> authManager.authenticate(null, targetServer));
+        assertThrows(ConstraintViolationException.class, () -> authManager.authenticate(null, true));
     }
 
     @Test
-    void authenticateNullTarget() {
-        assertThrows(ConstraintViolationException.class, () -> authManager.authenticate(HttpConstants.ALICE, null));
-    }
-
-    @Test
-    void authenticateNonAuthenticatingTarget() throws Exception {
+    void authenticateNonAuthenticating() throws Exception {
         when(clientRegistry.getClient(ClientRegistry.DEFAULT)).thenReturn(client);
-        final TargetServer targetServer = mock(TargetServer.class);
-        when(targetServer.getFeatures()).thenReturn(Collections.emptyMap());
-        final SolidClient solidClient = authManager.authenticate("ignored", targetServer);
+        final SolidClient solidClient = authManager.authenticate("ignored", false);
         assertTrue(solidClient.getClient().getUser().isEmpty());
     }
 
     @Test
     void authenticateAlreadyExists() throws Exception {
         final Client client = new Client.Builder("existing").build();
-        final TargetServer targetServer = getMockTargetServer();
         when(clientRegistry.hasClient("existing")).thenReturn(true);
         when(clientRegistry.getClient("existing")).thenReturn(client);
-        final SolidClient solidClient = authManager.authenticate("existing", targetServer);
+        final SolidClient solidClient = authManager.authenticate("existing", true);
         assertEquals("existing", solidClient.getClient().getUser());
         verify(config, never()).getCredentials("existing");
     }
 
     @Test
     void authenticateLocalhostNoOidc() {
-        final TargetServer targetServer = getMockTargetServer();
         when(config.getSolidIdentityProvider()).thenReturn(baseUri.resolve("/404/"));
         when(config.getServerRoot()).thenReturn(URI.create("https://localhost"));
         when(config.overridingTrust()).thenReturn(true);
         assertThrows(TestHarnessInitializationException.class,
-                () -> authManager.authenticate("test2", targetServer));
+                () -> authManager.authenticate("test2", true));
 
         final ArgumentCaptor<Client> argumentCaptor = ArgumentCaptor.forClass(Client.class);
         verify(clientRegistry).register(eq("test2"), argumentCaptor.capture());
@@ -129,13 +118,12 @@ class AuthManagerTest {
 
     @Test
     void authenticateLocalhostBadIssuer() {
-        final TargetServer targetServer = getMockTargetServer();
         when(config.getSolidIdentityProvider()).thenReturn(baseUri.resolve("/badissuer/"));
         when(config.getServerRoot()).thenReturn(URI.create("http://localhost"));
         when(config.overridingTrust()).thenReturn(true);
 
         assertThrows(TestHarnessInitializationException.class,
-                () -> authManager.authenticate("test3", targetServer));
+                () -> authManager.authenticate("test3", true));
 
         final ArgumentCaptor<Client> argumentCaptor = ArgumentCaptor.forClass(Client.class);
         verify(clientRegistry).register(eq("test3"), argumentCaptor.capture());
@@ -145,29 +133,26 @@ class AuthManagerTest {
 
     @Test
     void authenticateNullCredentials() {
-        final TargetServer targetServer = getMockTargetServer();
         when(config.getSolidIdentityProvider()).thenReturn(baseUri);
         when(config.getServerRoot()).thenReturn(URI.create(TestData.SAMPLE_BASE));
         when(config.getCredentials("test4")).thenReturn(null);
 
         assertThrows(TestHarnessInitializationException.class,
-                () -> authManager.authenticate("test4", targetServer));
+                () -> authManager.authenticate("test4", true));
     }
 
     @Test
     void authenticateMissingCredentials() {
-        final TargetServer targetServer = getMockTargetServer();
         when(config.getSolidIdentityProvider()).thenReturn(baseUri);
         when(config.getServerRoot()).thenReturn(URI.create(TestData.SAMPLE_BASE));
         when(config.getCredentials("test5")).thenReturn(new TestCredentials());
 
         assertThrows(TestHarnessInitializationException.class,
-                () -> authManager.authenticate("test5", targetServer));
+                () -> authManager.authenticate("test5", true));
     }
 
     @Test
     void authenticateRefreshCredentialsNoGrantType() {
-        final TargetServer targetServer = getMockTargetServer();
         when(config.getSolidIdentityProvider()).thenReturn(baseUri.resolve("/nogranttypes/"));
         when(config.getServerRoot()).thenReturn(URI.create(TestData.SAMPLE_BASE));
         final TestCredentials credentials = new TestCredentials();
@@ -177,14 +162,13 @@ class AuthManagerTest {
         when(config.getCredentials("refresh-nogrant")).thenReturn(credentials);
 
         final TestHarnessInitializationException exception = assertThrows(TestHarnessInitializationException.class,
-                () -> authManager.authenticate("refresh-nogrant", targetServer));
+                () -> authManager.authenticate("refresh-nogrant", true));
         assertEquals("Identity Provider does not support grant type: " + HttpConstants.REFRESH_TOKEN,
                 exception.getMessage());
     }
 
     @Test
     void authenticateRefreshCredentialsFails() {
-        final TargetServer targetServer = getMockTargetServer();
         when(config.getSolidIdentityProvider()).thenReturn(baseUri);
         when(config.getServerRoot()).thenReturn(URI.create(TestData.SAMPLE_BASE));
         final TestCredentials credentials = new TestCredentials();
@@ -194,14 +178,13 @@ class AuthManagerTest {
         when(config.getCredentials("test7")).thenReturn(credentials);
 
         final TestHarnessInitializationException exception = assertThrows(TestHarnessInitializationException.class,
-                () -> authManager.authenticate("test7", targetServer));
+                () -> authManager.authenticate("test7", true));
         assertEquals("Token exchange failed for grant type: " + HttpConstants.REFRESH_TOKEN,
                 exception.getMessage());
     }
 
     @Test
     void authenticateRefreshCredentials() throws Exception {
-        final TargetServer targetServer = getMockTargetServer();
         when(config.getSolidIdentityProvider()).thenReturn(baseUri);
         when(config.getServerRoot()).thenReturn(URI.create(TestData.SAMPLE_BASE));
         final TestCredentials credentials = new TestCredentials();
@@ -210,174 +193,160 @@ class AuthManagerTest {
         credentials.clientSecret = Optional.of("CLIENTSECRET");
         when(config.getCredentials("test6")).thenReturn(credentials);
 
-        final SolidClient solidClient = authManager.authenticate("test6", targetServer);
+        final SolidClient solidClient = authManager.authenticate("test6", true);
         assertEquals("ACCESS_TOKEN", solidClient.getClient().getAccessToken());
     }
 
     @Test
     void authenticateLoginSessionNoGrantType() {
-        final TargetServer targetServer = getMockTargetServer();
         when(clientRegistry.getClient(ClientRegistry.SESSION_BASED)).thenReturn(client);
         setupLogin(baseUri.resolve("/nogranttypes/"), "login-nogrant", "PASSWORD", "/login/password", null);
 
         final TestHarnessInitializationException exception = assertThrows(TestHarnessInitializationException.class,
-                () -> authManager.authenticate("login-nogrant", targetServer));
+                () -> authManager.authenticate("login-nogrant", true));
         assertEquals("Identity Provider does not support grant type: " + HttpConstants.AUTHORIZATION_CODE_TYPE,
                 exception.getMessage());
     }
 
     @Test
     void authenticateLoginSessionWithUserRegistrationFails() {
-        final TargetServer targetServer = getMockTargetServer();
         when(clientRegistry.getClient(ClientRegistry.SESSION_BASED)).thenReturn(client);
         when(config.getOrigin()).thenReturn("BADORIGIN");
         when(config.overridingTrust()).thenReturn(true);
         setupLogin(baseUri, "test18", "PASSWORD", null, "/idp/register");
 
         final TestHarnessInitializationException exception = assertThrows(TestHarnessInitializationException.class,
-                () -> authManager.authenticate("test18", targetServer));
+                () -> authManager.authenticate("test18", true));
         assertEquals("Registration failed with status code 400", exception.getMessage());
         verify(config, never()).getLoginEndpoint();
     }
 
     @Test
     void authenticateLoginSessionFails() {
-        final TargetServer targetServer = getMockTargetServer();
         when(clientRegistry.getClient(ClientRegistry.SESSION_BASED)).thenReturn(client);
         when(config.overridingTrust()).thenReturn(false);
         setupLogin(baseUri, "test8", "BADPASSWORD", "/login/password", null);
 
         final TestHarnessInitializationException exception = assertThrows(TestHarnessInitializationException.class,
-                () -> authManager.authenticate("test8", targetServer));
+                () -> authManager.authenticate("test8", true));
         assertEquals("Login failed with status code 403", exception.getMessage());
     }
 
     @Test
     void authenticateLoginRegisterFails() {
-        final TargetServer targetServer = getMockTargetServer();
         when(clientRegistry.getClient(ClientRegistry.SESSION_BASED)).thenReturn(client);
         when(config.getOrigin()).thenReturn("BADORIGIN");
         setupLogin(baseUri, "test9", "PASSWORD", "/login/password", null);
 
         final TestHarnessInitializationException exception = assertThrows(TestHarnessInitializationException.class,
-                () -> authManager.authenticate("test9", targetServer));
+                () -> authManager.authenticate("test9", true));
         assertEquals("Registration failed with status code 400", exception.getMessage());
     }
 
     @Test
     void authenticateLoginAuthorizationFails() {
-        final TargetServer targetServer = getMockTargetServer();
         when(clientRegistry.getClient(ClientRegistry.SESSION_BASED)).thenReturn(client);
         when(config.getOrigin()).thenReturn("AUTHFAIL");
         setupLogin(baseUri, "test10", "PASSWORD", "/login/password", null);
 
         final TestHarnessInitializationException exception = assertThrows(TestHarnessInitializationException.class,
-                () -> authManager.authenticate("test10", targetServer));
+                () -> authManager.authenticate("test10", true));
         assertEquals("Authorization failed with status code 400", exception.getMessage());
     }
 
     @Test
     void authenticateLoginAuthorizationFailsNoForm() {
-        final TargetServer targetServer = getMockTargetServer();
         when(clientRegistry.getClient(ClientRegistry.SESSION_BASED)).thenReturn(client);
         when(config.getOrigin()).thenReturn("https://origin/badform");
         setupLogin(baseUri, "test19", "PASSWORD", null, "/idp/register");
 
         final TestHarnessInitializationException exception = assertThrows(TestHarnessInitializationException.class,
-                () -> authManager.authenticate("test19", targetServer));
+                () -> authManager.authenticate("test19", true));
         assertEquals("Failed to follow authentication redirects", exception.getMessage());
         verify(config, never()).getLoginEndpoint();
     }
 
     @Test
     void authenticateLoginAuthorizationFailsFormBadLogin() {
-        final TargetServer targetServer = getMockTargetServer();
         when(clientRegistry.getClient(ClientRegistry.SESSION_BASED)).thenReturn(client);
         when(config.getOrigin()).thenReturn("https://origin/form");
         setupLogin(baseUri, "test20", "BADPASSWORD", null, "/idp/register");
 
         final TestHarnessInitializationException exception = assertThrows(TestHarnessInitializationException.class,
-                () -> authManager.authenticate("test20", targetServer));
+                () -> authManager.authenticate("test20", true));
         assertEquals("Authorization failed with status code 401", exception.getMessage());
         verify(config, never()).getLoginEndpoint();
     }
 
     @Test
     void authenticateLoginAuthorizationFailsFormGoodLoginBadCode() {
-        final TargetServer targetServer = getMockTargetServer();
         when(clientRegistry.getClient(ClientRegistry.SESSION_BASED)).thenReturn(client);
         when(config.getOrigin()).thenReturn("https://origin/form");
         setupLogin(baseUri, "test21", "PASSWORD", null, "/idp/register");
 
         final TestHarnessInitializationException exception = assertThrows(TestHarnessInitializationException.class,
-                () -> authManager.authenticate("test21", targetServer));
+                () -> authManager.authenticate("test21", true));
         assertEquals("Token exchange failed for grant type: authorization_code", exception.getMessage());
         verify(config, never()).getLoginEndpoint();
     }
 
     @Test
     void authenticateLoginAuthorizationFailsWithoutRedirect() {
-        final TargetServer targetServer = getMockTargetServer();
         when(clientRegistry.getClient(ClientRegistry.SESSION_BASED)).thenReturn(client);
         when(config.getOrigin()).thenReturn("https://origin/noredirect");
         setupLogin(baseUri, "test11", "PASSWORD", "/login/password", null);
 
         final TestHarnessInitializationException exception = assertThrows(TestHarnessInitializationException.class,
-                () -> authManager.authenticate("test11", targetServer));
+                () -> authManager.authenticate("test11", true));
         assertEquals("Failed to follow authentication redirects", exception.getMessage());
     }
 
     @Test
     void authenticateLoginNoRedirectFailsNoCode() {
-        final TargetServer targetServer = getMockTargetServer();
         when(clientRegistry.getClient(ClientRegistry.SESSION_BASED)).thenReturn(client);
         when(config.getOrigin()).thenReturn("https://origin/immediate");
         setupLogin(baseUri, "test12", "PASSWORD", "/login/password", null);
 
         final TestHarnessInitializationException exception = assertThrows(TestHarnessInitializationException.class,
-                () -> authManager.authenticate("test12", targetServer));
+                () -> authManager.authenticate("test12", true));
         assertEquals("Failed to get authorization code", exception.getMessage());
     }
 
     @Test
     void authenticateLoginOneRedirectFailsNoCode() {
-        final TargetServer targetServer = getMockTargetServer();
         when(clientRegistry.getClient(ClientRegistry.SESSION_BASED)).thenReturn(client);
         when(config.getOrigin()).thenReturn("https://origin/redirect");
         setupLogin(baseUri, "test13", "PASSWORD", "/login/password", null);
 
         final TestHarnessInitializationException exception = assertThrows(TestHarnessInitializationException.class,
-                () -> authManager.authenticate("test13", targetServer));
+                () -> authManager.authenticate("test13", true));
         assertEquals("Failed to get authorization code", exception.getMessage());
     }
 
     @Test
     void authenticateLoginTokenFails() {
-        final TargetServer targetServer = getMockTargetServer();
         when(clientRegistry.getClient(ClientRegistry.SESSION_BASED)).thenReturn(client);
         when(config.getOrigin()).thenReturn("https://origin/badcode");
         setupLogin(baseUri, "test14", "PASSWORD", "/login/password", null);
 
         final TestHarnessInitializationException exception = assertThrows(TestHarnessInitializationException.class,
-                () -> authManager.authenticate("test14", targetServer));
+                () -> authManager.authenticate("test14", true));
         assertEquals("Token exchange failed for grant type: " + HttpConstants.AUTHORIZATION_CODE_TYPE,
                 exception.getMessage());
     }
 
     @Test
     void authenticateLoginTokenSucceeds() throws Exception {
-        final TargetServer targetServer = getMockTargetServer();
         when(clientRegistry.getClient(ClientRegistry.SESSION_BASED)).thenReturn(client);
         when(config.getOrigin()).thenReturn("https://origin/goodcode");
         setupLogin(baseUri, "test15", "PASSWORD", "/login/password", null);
 
-        final SolidClient solidClient = authManager.authenticate("test15", targetServer);
+        final SolidClient solidClient = authManager.authenticate("test15", true);
         assertEquals("ACCESS_TOKEN", solidClient.getClient().getAccessToken());
     }
 
     @Test
     void authenticateClientCredentialsNoGrantType() {
-        final TargetServer targetServer = getMockTargetServer();
         when(config.getSolidIdentityProvider()).thenReturn(baseUri.resolve("/nogranttypes/"));
         when(config.getServerRoot()).thenReturn(URI.create(TestData.SAMPLE_BASE));
         final TestCredentials credentials = new TestCredentials();
@@ -385,14 +354,13 @@ class AuthManagerTest {
         when(config.getCredentials("client-nogrant")).thenReturn(credentials);
 
         final TestHarnessInitializationException exception = assertThrows(TestHarnessInitializationException.class,
-                () -> authManager.authenticate("client-nogrant", targetServer));
+                () -> authManager.authenticate("client-nogrant", true));
         assertEquals("Identity Provider does not support grant type: " + HttpConstants.CLIENT_CREDENTIALS,
                 exception.getMessage());
     }
 
     @Test
     void authenticateClientCredentialsFails() {
-        final TargetServer targetServer = getMockTargetServer();
         when(config.getSolidIdentityProvider()).thenReturn(baseUri);
         when(config.getServerRoot()).thenReturn(URI.create(TestData.SAMPLE_BASE));
         final TestCredentials credentials = new TestCredentials();
@@ -401,14 +369,13 @@ class AuthManagerTest {
         when(config.getCredentials("test16")).thenReturn(credentials);
 
         final TestHarnessInitializationException exception = assertThrows(TestHarnessInitializationException.class,
-                () -> authManager.authenticate("test16", targetServer));
+                () -> authManager.authenticate("test16", true));
         assertEquals("Token exchange failed for grant type: " + HttpConstants.CLIENT_CREDENTIALS,
                 exception.getMessage());
     }
 
     @Test
     void authenticateClientCredentials() throws Exception {
-        final TargetServer targetServer = getMockTargetServer();
         when(config.getSolidIdentityProvider()).thenReturn(baseUri);
         when(config.getServerRoot()).thenReturn(URI.create(TestData.SAMPLE_BASE));
         final TestCredentials credentials = new TestCredentials();
@@ -416,18 +383,12 @@ class AuthManagerTest {
         credentials.clientSecret = Optional.of("CLIENTSECRET");
         when(config.getCredentials("test17")).thenReturn(credentials);
 
-        final SolidClient solidClient = authManager.authenticate("test17", targetServer);
+        final SolidClient solidClient = authManager.authenticate("test17", true);
         assertEquals("ACCESS_TOKEN", solidClient.getClient().getAccessToken());
     }
 
     public void setBaseUri(final URI baseUri) {
         this.baseUri = baseUri;
-    }
-
-    private TargetServer getMockTargetServer() {
-        final TargetServer targetServer = mock(TargetServer.class);
-        when(targetServer.getFeatures()).thenReturn(Map.of("authentication", true));
-        return targetServer;
     }
 
     private void setupLogin(final URI idpBaseUri, final String testId, final String password,

--- a/src/test/java/org/solid/testharness/http/SolidClientTest.java
+++ b/src/test/java/org/solid/testharness/http/SolidClientTest.java
@@ -191,7 +191,7 @@ class SolidClientTest {
     }
 
     @Test
-    void getAclUriFromHeaders() {
+    void getAclUriFromHeadersWAC() {
         final Map<String, List<String>> headerMap = Map.of("Link",
                 List.of("<http://localhost:3000/test.acl>; rel=\"acl\""));
         final HttpHeaders headers = HttpHeaders.of(headerMap, (k, v) -> true);
@@ -199,6 +199,17 @@ class SolidClientTest {
         final SolidClient solidClient = new SolidClient();
         final URI uri = solidClient.getAclUri(headers);
         assertEquals(URI.create("http://localhost:3000/test.acl"), uri);
+    }
+
+    @Test
+    void getAclUriFromHeadersACP() {
+        final Map<String, List<String>> headerMap = Map.of("Link",
+                List.of("<http://localhost:3000/test?ext=acr>; rel=\"http://www.w3.org/ns/solid/acp#accessControl\""));
+        final HttpHeaders headers = HttpHeaders.of(headerMap, (k, v) -> true);
+
+        final SolidClient solidClient = new SolidClient();
+        final URI uri = solidClient.getAclUri(headers);
+        assertEquals(URI.create("http://localhost:3000/test?ext=acr"), uri);
     }
 
     @Test

--- a/src/test/java/org/solid/testharness/http/SolidClientTest.java
+++ b/src/test/java/org/solid/testharness/http/SolidClientTest.java
@@ -169,48 +169,48 @@ class SolidClientTest {
     }
 
     @Test
-    void getResourceAclLink() throws IOException, InterruptedException {
+    void getAclUriFromUri() throws IOException, InterruptedException {
         final Client mockClient = mock(Client.class);
         final HttpResponse<Void> mockResponse = TestUtils.mockVoidResponse(204, Map.of(HttpConstants.HEADER_LINK,
                 List.of("<http://localhost:3000/test.acl>; rel=\"acl\"")));
         when(mockClient.head(any())).thenReturn(mockResponse);
 
         final SolidClient solidClient = new SolidClient(mockClient);
-        final URI uri = solidClient.getResourceAclLink(URI.create("http://localhost:3000/test"));
+        final URI uri = solidClient.getAclUri(URI.create("http://localhost:3000/test"));
         assertEquals(URI.create("http://localhost:3000/test.acl"), uri);
         verify(mockClient).head(URI.create("http://localhost:3000/test"));
     }
 
     @Test
-    void getResourceAclLinkFails() throws IOException, InterruptedException {
+    void getAclUriFails() throws IOException, InterruptedException {
         final Client mockClient = mock(Client.class);
         when(mockClient.head(any())).thenThrow(new IOException("Failed"));
 
         final SolidClient solidClient = new SolidClient(mockClient);
-        assertThrows(IOException.class, () -> solidClient.getResourceAclLink(URI.create("http://localhost:3000/test")));
+        assertThrows(IOException.class, () -> solidClient.getAclUri(URI.create("http://localhost:3000/test")));
     }
 
     @Test
-    void getAclLink() {
+    void getAclUriFromHeaders() {
         final Map<String, List<String>> headerMap = Map.of("Link",
                 List.of("<http://localhost:3000/test.acl>; rel=\"acl\""));
         final HttpHeaders headers = HttpHeaders.of(headerMap, (k, v) -> true);
 
         final SolidClient solidClient = new SolidClient();
-        final URI uri = solidClient.getAclLink(headers);
+        final URI uri = solidClient.getAclUri(headers);
         assertEquals(URI.create("http://localhost:3000/test.acl"), uri);
     }
 
     @Test
-    void getAclLinkMissing() {
+    void getAclUriMissing() {
         final HttpHeaders headers = HttpHeaders.of(Collections.emptyMap(), (k, v) -> true);
 
         final SolidClient solidClient = new SolidClient();
-        assertNull(solidClient.getAclLink(headers));
+        assertNull(solidClient.getAclUri(headers));
     }
 
     @Test
-    void getAclLinkMultiple() {
+    void getAclUriMultiple() {
         final Map<String, List<String>> headerMap = Map.of(HttpConstants.HEADER_LINK, List.of(
                 "<http://localhost:3000/test.acl>; rel=\"acl\"",
                 "<http://localhost:3000/test.acl2>; rel=\"acl\""
@@ -218,7 +218,7 @@ class SolidClientTest {
         final HttpHeaders headers = HttpHeaders.of(headerMap, (k, v) -> true);
 
         final SolidClient solidClient = new SolidClient();
-        final URI uri = solidClient.getAclLink(headers);
+        final URI uri = solidClient.getAclUri(headers);
         assertEquals(URI.create("http://localhost:3000/test.acl"), uri);
     }
 

--- a/src/test/java/org/solid/testharness/utils/SolidResourceTest.java
+++ b/src/test/java/org/solid/testharness/utils/SolidResourceTest.java
@@ -93,8 +93,8 @@ class SolidResourceTest {
                 List.of("<" + aclUrl.toString() + ">; rel=\"acl\""));
         final HttpHeaders headers = HttpHeaders.of(headerMap, (k, v) -> true);
         when(solidClient.createResource(testUrl, "hello", HttpConstants.MEDIA_TYPE_TEXT_PLAIN)).thenReturn(headers);
-        when(solidClient.getAclLink(headers)).thenReturn(aclUrl);
-        when(solidClient.getResourceAclLink(testUrl)).thenReturn(aclUrl);
+        when(solidClient.getAclUri(headers)).thenReturn(aclUrl);
+        when(solidClient.getAclUri(testUrl)).thenReturn(aclUrl);
 
         final SolidResource resource = new SolidResource(solidClient, testUrl.toString(), "hello",
                 HttpConstants.MEDIA_TYPE_TEXT_PLAIN);
@@ -109,7 +109,7 @@ class SolidResourceTest {
                 List.of("<" + aclUrl + ">; rel=\"noacl\""));
         final HttpHeaders headers = HttpHeaders.of(headerMap, (k, v) -> true);
         when(solidClient.createResource(testUrl, "hello", HttpConstants.MEDIA_TYPE_TEXT_PLAIN)).thenReturn(headers);
-        when(solidClient.getResourceAclLink(testUrl)).thenReturn(null);
+        when(solidClient.getAclUri(testUrl)).thenReturn(null);
 
         final SolidResource resource = new SolidResource(solidClient, testUrl.toString(), "hello",
                 HttpConstants.MEDIA_TYPE_TEXT_PLAIN);
@@ -135,7 +135,7 @@ class SolidResourceTest {
     void resourceExistsWithAclAfterLookup() throws Exception {
         when(solidClient.createResource(testUrl, "hello", HttpConstants.MEDIA_TYPE_TEXT_PLAIN)).thenReturn(null);
         final URI lookedUpAclUrl = URI.create("http://localhost/lookupedUpAcl");
-        when(solidClient.getResourceAclLink(testUrl)).thenReturn(lookedUpAclUrl);
+        when(solidClient.getAclUri(testUrl)).thenReturn(lookedUpAclUrl);
 
         final SolidResource resource = new SolidResource(solidClient, testUrl.toString(), "hello",
                 HttpConstants.MEDIA_TYPE_TEXT_PLAIN);
@@ -205,43 +205,43 @@ class SolidResourceTest {
     }
 
     @Test
-    void setAclNoUrl() throws Exception {
+    void setAccessDatasetNoUrl() throws Exception {
         when(solidClient.createResource(testUrl, "hello", HttpConstants.MEDIA_TYPE_TEXT_PLAIN)).thenReturn(null);
         final SolidResource resource = new SolidResource(solidClient, TEST_URL, "hello",
                 HttpConstants.MEDIA_TYPE_TEXT_PLAIN);
-        assertFalse(resource.setAcl("acl"));
+        assertFalse(resource.setAccessDataset("acl"));
     }
 
     @Test
-    void setAclMissing() throws Exception {
+    void setAccessDatasetMissing() throws Exception {
         final Map<String, List<String>> headerMap = Map.of(HttpConstants.HEADER_LINK,
                 List.of("<" + aclUrl.toString() + ">; rel=\"acl\""));
         final HttpHeaders headers = HttpHeaders.of(headerMap, (k, v) -> true);
         when(solidClient.createResource(testUrl, "hello", HttpConstants.MEDIA_TYPE_TEXT_PLAIN)).thenReturn(headers);
-        when(solidClient.getAclLink(headers)).thenReturn(null);
-        when(solidClient.getResourceAclLink(testUrl)).thenReturn(null);
+        when(solidClient.getAclUri(headers)).thenReturn(null);
+        when(solidClient.getAclUri(testUrl)).thenReturn(null);
 
         final SolidResource resource = new SolidResource(solidClient, testUrl.toString(), "hello",
                 HttpConstants.MEDIA_TYPE_TEXT_PLAIN);
-        assertFalse(resource.setAcl("acl"));
+        assertFalse(resource.setAccessDataset("acl"));
         // second attempt short cuts as false
-        assertFalse(resource.setAcl("acl"));
+        assertFalse(resource.setAccessDataset("acl"));
     }
 
     @Test
-    void setAcl() throws Exception {
+    void setAccessDataset() throws Exception {
         final Map<String, List<String>> headerMap = Map.of(HttpConstants.HEADER_LINK,
                 List.of("<" + aclUrl.toString() + ">; rel=\"acl\""));
         final HttpHeaders headers = HttpHeaders.of(headerMap, (k, v) -> true);
         when(solidClient.createResource(testUrl, "hello", HttpConstants.MEDIA_TYPE_TEXT_PLAIN)).thenReturn(headers);
-        when(solidClient.getAclLink(headers)).thenReturn(aclUrl);
-        when(solidClient.getResourceAclLink(testUrl)).thenReturn(aclUrl);
+        when(solidClient.getAclUri(headers)).thenReturn(aclUrl);
+        when(solidClient.getAclUri(testUrl)).thenReturn(aclUrl);
         when(solidClient.createAcl(aclUrl, "acl")).thenReturn(true);
 
         when(solidClient.createResource(testUrl, "hello", HttpConstants.MEDIA_TYPE_TEXT_PLAIN)).thenReturn(headers);
         final SolidResource resource = new SolidResource(solidClient, TEST_URL, "hello",
                 HttpConstants.MEDIA_TYPE_TEXT_PLAIN);
-        assertTrue(resource.setAcl("acl"));
+        assertTrue(resource.setAccessDataset("acl"));
     }
 
     @Test
@@ -270,8 +270,8 @@ class SolidResourceTest {
                 List.of("<" + aclUrl.toString() + ">; rel=\"acl\""));
         final HttpHeaders headers = HttpHeaders.of(headerMap, (k, v) -> true);
         when(solidClient.createResource(testUrl, "hello", HttpConstants.MEDIA_TYPE_TEXT_PLAIN)).thenReturn(headers);
-        when(solidClient.getAclLink(headers)).thenReturn(null);
-        when(solidClient.getResourceAclLink(testUrl)).thenReturn(null);
+        when(solidClient.getAclUri(headers)).thenReturn(null);
+        when(solidClient.getAclUri(testUrl)).thenReturn(null);
 
         final SolidResource resource = new SolidResource(solidClient, testUrl.toString(), "hello",
                 HttpConstants.MEDIA_TYPE_TEXT_PLAIN);
@@ -297,18 +297,18 @@ class SolidResourceTest {
     }
 
     @Test
-    void getAccessControls() throws Exception {
-        when(solidClient.getResourceAclLink(testUrl)).thenReturn(aclUrl);
+    void getAccessDataset() throws Exception {
+        when(solidClient.getAclUri(testUrl)).thenReturn(aclUrl);
         when(solidClient.getAcl(aclUrl)).thenReturn("ACL");
         final SolidResource resource = new SolidResource(solidClient, testUrl.toString());
-        assertEquals("ACL", resource.getAccessControls());
+        assertEquals("ACL", resource.getAccessDataset());
     }
 
     @Test
-    void getAccessControlsMissing() throws Exception {
-        when(solidClient.getResourceAclLink(testUrl)).thenReturn(null);
+    void getAccessDatasetMissing() throws Exception {
+        when(solidClient.getAclUri(testUrl)).thenReturn(null);
         final SolidResource resource = new SolidResource(solidClient, testUrl.toString());
-        assertEquals("", resource.getAccessControls());
+        assertEquals("", resource.getAccessDataset());
     }
 
     @Test


### PR DESCRIPTION
The first commit renames some of the key functions for accessing acl resources.
The second was in preparation for a client needing to know whether to use ACP or WAC. I noticed that the steps for registering users and setting them up as http clients was part of the TestSubject class but is not really relevant to that. It is more related to using extenal IdPs to prepare the test harness. Once everything is set up, the test harness will discover whether it is working with WAC or ACP and set up the correct AccessControl builder class.