### PR TITLE
Removed pod-compat references

### DIFF
--- a/config/application.yaml
+++ b/config/application.yaml
@@ -6,8 +6,7 @@
     - https://github.com/solid/conformance-test-harness/example/web-access-control/web-access-control-test-manifest.ttl
     - https://github.com/solid/conformance-test-harness/example/protocol/solid-protocol-spec.ttl
     - https://github.com/solid/conformance-test-harness/example/web-access-control/web-access-control-spec.ttl
-  target: https://github.com/solid/conformance-test-harness/ess-compat
-#  target: https://github.com/solid/conformance-test-harness/ess
+  target: https://github.com/solid/conformance-test-harness/ess
 #  target: https://github.com/solid/conformance-test-harness/css
 #  target: https://github.com/solid/conformance-test-harness/nss
 #  target: https://github.com/solid/conformance-test-harness/trinpod

--- a/config/test-subjects.ttl
+++ b/config/test-subjects.ttl
@@ -10,19 +10,6 @@ prefix earl: <http://www.w3.org/ns/earl#>
 prefix solid: <http://www.w3.org/ns/solid/terms#>
 prefix dcterms: <http://purl.org/dc/terms/>
 
-<ess-compat>
-    a earl:Software, earl:TestSubject ;
-    doap:name "Enterprise Solid Server (Web Access Control version)";
-    doap:release [
-        doap:name "ESS 1.1.2";
-        doap:revision "1.1.2";
-        doap:created "2021-05-24"^^xsd:date
-    ];
-    doap:developer <https://inrupt.com/profile/card/#us>;
-    doap:homepage <https://inrupt.com/products/enterprise-solid-server>;
-    doap:description "A production-grade Solid server produced and supported by Inrupt."@en;
-    doap:programming-language "Java" ;
-    solid-test:features "authentication", "acl", "wac-allow" .
 
 <ess>
     a earl:Software, earl:TestSubject ;

--- a/src/main/docker/application.yaml
+++ b/src/main/docker/application.yaml
@@ -4,7 +4,7 @@ sources:
   - /data/web-access-control/web-access-control-test-manifest.ttl
   - /data/protocol/solid-protocol-spec.ttl
   - /data/web-access-control/web-access-control-spec.ttl
-target: https://github.com/solid/conformance-test-harness/ess-compat
+target: https://github.com/solid/conformance-test-harness/css
 mappings:
   - prefix: https://github.com/solid/specification-tests/
     path: /data/


### PR DESCRIPTION
Removed references to the deprecated pod-compat.inrupt.com Solid server.