### PR TITLE
Update quarkus and karate as they are interdependant

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,8 +33,8 @@
         <jacoco-plugin.version>0.8.7</jacoco-plugin.version>
 
         <!-- dependencies -->
-        <quarkus.version>2.1.3.Final</quarkus.version>
-        <karate.version>1.0.1</karate.version>
+        <quarkus.version>2.2.2.Final</quarkus.version>
+        <karate.version>1.1.0</karate.version>
         <hamcrest.version>2.2</hamcrest.version>
         <rdf4j.version>3.7.2</rdf4j.version>
         <semargl.version>0.7</semargl.version>

--- a/src/main/java/org/solid/testharness/TestRunner.java
+++ b/src/main/java/org/solid/testharness/TestRunner.java
@@ -53,9 +53,7 @@ public class TestRunner {
 //                .outputHtmlReport(true)
 //                .parallel(8);
 
-        Runner.Builder builder = Runner.builder()
-                .path(featurePaths)
-                .tags("~@ignore");
+        Runner.Builder builder = Runner.builder().path(featurePaths);
         if (enableReporting) {
             builder = builder.outputHtmlReport(true).suiteReports(featureResultHandler);
         }


### PR DESCRIPTION
* Quarkus 2.1.3Final & Karate 1.0.1 used org.graalvm.sdk:graal-sdk v21.1.0
* Quarkus 2.2.2Final updated this to v21.2.0 whilst leaving the rest of Graal at v21.0.0
* Karate 1.1.0 update it to v21.1.0 whilst upgrading the rest of Graal to v21.2.0
* Upgrading both libraries made everything consistent on v21.2.0