### PR TITLE
Omit language tag on some literals

### DIFF
--- a/src/main/java/org/solid/testharness/ConformanceTestHarness.java
+++ b/src/main/java/org/solid/testharness/ConformanceTestHarness.java
@@ -94,7 +94,7 @@ public class ConformanceTestHarness {
                 final IRI release = iri(Namespaces.RESULTS_URI, "assertor-release");
                 conn.add(builder.subject(assertor)
                         .add(RDF.type, EARL.Software)
-                        .add(DOAP.name, literal(properties.getProperty("package.name"), "en"))
+                        .add(DOAP.name, properties.getProperty("package.name"))
                         .add(DOAP.description, literal(properties.getProperty("package.description"), "en"))
                         .add(DOAP.created, Date.from(
                                 Instant.from(DateTimeFormatter.ISO_INSTANT
@@ -102,8 +102,9 @@ public class ConformanceTestHarness {
                         ))
                         .add(DOAP.developer, iri(properties.getProperty("package.organizationUrl")))
                         .add(DOAP.homepage, iri(properties.getProperty("package.url")))
+                        .add(DOAP.programming_language, "Java, Karate")
                         .add(DOAP.release, release)
-                        .add(release, DOAP.revision, literal(properties.getProperty("package.version"), "en"))
+                        .add(release, DOAP.revision, properties.getProperty("package.version"))
                         .build());
             }
         }

--- a/src/main/resources/templates/assertor.html
+++ b/src/main/resources/templates/assertor.html
@@ -1,14 +1,15 @@
 <section about="{subject}" id="assertor" typeof="{typesList}">
   <h2>Assertor</h2>
-  <dl><dt>Name</dt><dd property="doap:name">{softwareName}</dd></dl>
+  <dl><dt>Name</dt><dd property="doap:name" lang="" xml:lang="">{softwareName}</dd></dl>
   <dl><dt>Description</dt><dd property="doap:description">{description}</dd></dl>
   <dl><dt>Created</dt><dd><time datatype="xsd:date" datetime="{createdDate}" property="doap:created">{createdDate}</time></dd></dl>
   <dl><dt>Developer</dt><dd><a href="{developer}" rel="doap:developer">{developer}</a></dd></dl>
   <dl><dt>Homepage</dt><dd><a href="{homepage}" rel="doap:homepage">{homepage}</a></dd></dl>
+  <dl><dt>Programming Language</dt><dd property="doap:programming-language" lang="" xml:lang="">Java, Karate</dd></dl>
   <dl>
     <dt>Version</dt>
     <dd rel="doap:release" resource="#assertor-release">
-      <span property="doap:revision">{revision}</span>
+      <span property="doap:revision" lang="" xml:lang="">{revision}</span>
     </dd>
   </dl>
 </section>

--- a/src/main/resources/templates/test-subject.html
+++ b/src/main/resources/templates/test-subject.html
@@ -1,14 +1,14 @@
 <section about="{subject}" id="test-subject" typeof="{typesList}">
   <h2>Test subject</h2>
-  <dl><dt>Name</dt><dd property="doap:name">{softwareName}</dd></dl>
+  <dl><dt>Name</dt><dd property="doap:name" lang="" xml:lang="">{softwareName}</dd></dl>
   <dl><dt>Description</dt><dd property="doap:description">{description}</dd></dl>
   <dl><dt>Developer</dt><dd><a href="{developer}" rel="doap:developer">{developer}</a></dd></dl>
   <dl><dt>Homepage</dt><dd><a href="{homepage}" rel="doap:homepage">{homepage}</a></dd></dl>
-  <dl><dt>Programming Language</dt><dd property="doap:programming-language">{programmingLanguage}</dd></dl>
+  <dl><dt>Programming Language</dt><dd property="doap:programming-language" lang="" xml:lang="">{programmingLanguage}</dd></dl>
   <dl>
     <dt>Version</dt>
     <dd rel="doap:release" resource="{subject}#test-subject-release">
-      <span property="doap:name">{releaseName}</span>
+      <span property="doap:name" lang="" xml:lang="">{releaseName}</span>
       (<time datatype="xsd:date" datetime="{createdDate}" property="doap:created">{createdDate}</time>)
       <span content="{revision}" lang="" property="doap:revision" xml:lang=""></span>
     </dd>

--- a/src/test/resources/config/config-sample-bad.ttl
+++ b/src/test/resources/config/config-sample-bad.ttl
@@ -9,4 +9,4 @@ prefix solid: <http://www.w3.org/ns/solid/terms#>
 
 <example>
     a earl:Software, earl:TestSubject ;
-    doap:name "Example server"@en .
+    doap:name "Example server" .

--- a/src/test/resources/config/config-sample-single.ttl
+++ b/src/test/resources/config/config-sample-single.ttl
@@ -9,15 +9,15 @@ prefix solid: <http://www.w3.org/ns/solid/terms#>
 
 <default>
     a earl:Software, earl:TestSubject ;
-    doap:name "Enterprise Solid Server (Web Access Control version)"@en;
+    doap:name "Enterprise Solid Server (Web Access Control version)";
     doap:release <default#test-subject-release> ;
     doap:developer <https://inrupt.com/profile/card/#us>;
     doap:homepage <https://inrupt.com/products/enterprise-solid-server>;
     doap:description "A production-grade Solid server produced and supported by Inrupt."@en;
-    doap:programming-language "Java"@en ;
+    doap:programming-language "Java" ;
     solid-test:features "authentication", "acl", "wac-allow" .
 
 <default#test-subject-release>
-    doap:name "ESS 1.0.9"@en;
-    doap:revision "1.0.9"@en;
+    doap:name "ESS 1.0.9";
+    doap:revision "1.0.9";
     doap:created "2021-03-05"^^xsd:date .

--- a/src/test/resources/config/config-sample.ttl
+++ b/src/test/resources/config/config-sample.ttl
@@ -9,30 +9,30 @@
 
 <testserver>
     a earl:Software, earl:TestSubject ;
-    doap:name "Enterprise Solid Server (Web Access Control version)"@en ;
+    doap:name "Enterprise Solid Server (Web Access Control version)" ;
     doap:release <testserver#test-subject-release> ;
     doap:developer <https://inrupt.com/profile/card/#us> ;
     doap:homepage <https://inrupt.com/products/enterprise-solid-server> ;
     doap:description "A production-grade Solid server produced and supported by Inrupt."@en ;
-    doap:programming-language "Java"@en ;
+    doap:programming-language "Java" ;
     solid-test:features "authentication", "acl", "wac-allow" .
 
 <testserver#test-subject-release>
-    doap:name "ESS 1.0.9"@en ;
-    doap:revision "1.0.9"@en ;
+    doap:name "ESS 1.0.9" ;
+    doap:revision "1.0.9" ;
     doap:created "2021-03-05"^^xsd:date .
 
 <testserver2>
     a earl:Software, earl:TestSubject ;
-    doap:name "Community Solid Server"@en ;
+    doap:name "Community Solid Server" ;
     doap:release <testserver2#test-subject-release> ;
     doap:developer <https://github.com/solid> ;
     doap:homepage <https://github.com/solid/community-server> ;
     doap:description "An open and modular implementation of the Solid specifications."@en ;
-    doap:programming-language "TypeScript"@en ;
+    doap:programming-language "TypeScript" ;
     solid-test:features "authentication", "acl", "wac-allow" .
 
 <testserver2#test-subject-release>
-    doap:name "CSS 0.8.0"@en ;
-    doap:revision "0.8.0"@en ;
+    doap:name "CSS 0.8.0" ;
+    doap:revision "0.8.0" ;
     doap:created "2021-03-04"^^xsd:date .

--- a/src/test/resources/config/harness-sample.ttl
+++ b/src/test/resources/config/harness-sample.ttl
@@ -5,11 +5,12 @@
 @prefix earl: <http://www.w3.org/ns/earl#> .
 
 <> a earl:Software ;
-   doap:name "Solid Specification Conformance Test Harness"@en ;
+   doap:name "Solid Specification Conformance Test Harness" ;
    doap:description "A test harness that will run suites of tests related to Solid specifications."@en ;
+   doap:programming-language "Java, Karate" ;
    doap:created "2021-02-16"^^xsd:date ;
    doap:developer <https://inrupt.com/profile/card/#us>;
    doap:homepage <https://github.com/solid/conformance-test-harness> ;
    doap:release <#assertor-release> .
 
-<#assertor-release> doap:revision "0.0.1-SNAPSHOT"@en .
+<#assertor-release> doap:revision "0.0.1-SNAPSHOT" .

--- a/src/test/resources/config/targetserver-testing-feature.ttl
+++ b/src/test/resources/config/targetserver-testing-feature.ttl
@@ -6,17 +6,17 @@ prefix solid: <http://www.w3.org/ns/solid/terms#>
 
 <testserver>
     a earl:Software, earl:TestSubject ;
-    doap:name "Enterprise Solid Server (Web Access Control version)"@en;
+    doap:name "Enterprise Solid Server (Web Access Control version)";
     doap:release <testserver#test-subject-release> ;
     doap:developer <https://inrupt.com/profile/card/#us>;
     doap:homepage <https://inrupt.com/products/enterprise-solid-server>;
     doap:description "A production-grade Solid server produced and supported by Inrupt."@en;
-    doap:programming-language "Java"@en ;
+    doap:programming-language "Java" ;
     solid-test:features "feature1" .
 
 <testserver#test-subject-release>
-    doap:name "ESS 1.0.9"@en;
-    doap:revision "1.0.9"@en;
+    doap:name "ESS 1.0.9";
+    doap:revision "1.0.9";
     doap:created "2021-03-05"^^xsd:date .
 
 <bad> a earl:Software, earl:TestSubject .

--- a/src/test/resources/reporting/assertor-testing-feature.ttl
+++ b/src/test/resources/reporting/assertor-testing-feature.ttl
@@ -5,13 +5,14 @@ prefix doap: <http://usefulinc.com/ns/doap#>
 prefix earl: <http://www.w3.org/ns/earl#>
 
 <tester1> a earl:Software ;
-   doap:name "TESTER1"@en ;
+   doap:name "TESTER1" ;
    doap:description "DESCRIPTION"@en ;
+   doap:programming-language "Java, Karate" ;
    doap:created "2021-01-01"^^xsd:date ;
    doap:developer <https://example.org/profile/card/#us>;
    doap:homepage <https://example.org/tester> ;
    doap:release <tester1#assertor-release> .
 
-<tester1#assertor-release> doap:revision "0.0.1-SNAPSHOT"@en .
+<tester1#assertor-release> doap:revision "0.0.1-SNAPSHOT" .
 
 <tester2> a earl:Software.

--- a/src/test/resources/reporting/testsubject-testing-feature.ttl
+++ b/src/test/resources/reporting/testsubject-testing-feature.ttl
@@ -5,16 +5,16 @@ prefix doap: <http://usefulinc.com/ns/doap#>
 prefix earl: <http://www.w3.org/ns/earl#>
 
 <testSubject1> a earl:Software ;
-   doap:name "TESTER1"@en ;
+   doap:name "TESTER1" ;
    doap:description "DESCRIPTION"@en ;
-   doap:programming-language "LANG"@en ;
+   doap:programming-language "LANG" ;
    doap:developer <https://example.org/profile/card/#us>;
    doap:homepage <https://example.org/testSubject1> ;
    doap:release <testSubject1#test-subject-release> .
 
 <testSubject1#test-subject-release>
-    doap:name "RELEASE_NAME"@en;
-    doap:revision "0.0.1-SNAPSHOT"@en ;
+    doap:name "RELEASE_NAME";
+    doap:revision "0.0.1-SNAPSHOT" ;
     doap:created "2021-03-05"^^xsd:date .
 
 <testSubject2> a earl:Software.


### PR DESCRIPTION
The language tag is inherited from an ancestor node. The default language of the HTML document is set to "en" but that can potentially be different if reports are generated using different languages - provided the templating system takes that into account. Some literals should not have a language tag.

This PR removes it from `doap:revision` but there are others that should be reviewed. For example, `doap:name` is not necessarily in "en" or any specific language, such as the use alongside `doap:release`. Same applies for people (maintainers) or org names if mentioned.. In such cases, it may be safer/simpler to omit the lang altogether.

Perhaps the simple ones can be addressed as part of this PR..

Revisit https://github.com/solid/conformance-test-harness/issues/121