### PR TITLE
Simplify config so no actual test subject is referenced

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,14 +111,11 @@ mappings:
   - prefix: https://github.com/solid/conformance-test-harness/example
     path: example
 ```
-This method works well when running your tests in an Integrated Development Environemnt (IDE) as it doesn't require anything adding to the command line.
+This method works well when running your tests in an Integrated Development Environemnt (IDE) as it doesn't require
+anything adding to the command line. If there is only one test subject defined in the `test-subjects.ttl` file, then the
+target property can be omitted as this will be selected by default.
 
 Alternatively, you can set these as command line options as described later. 
-
-**Note**: During development, you can select a target using:
-```
--Dtarget=TARGET_SERVER_IRI
-``` 
 
 ### 3. Build and Test
 To run the unit tests on the Test Harness itself:
@@ -127,14 +124,9 @@ To run the unit tests on the Test Harness itself:
 ```
 The test coverage report is available here:`target/site/jacoco/index.html`
 
-To run the test suite with the default target server as defined in `config/application.yaml`:
+To run the test suite against whichever server is configured in your `.env` file:
 ```shell
 ./mvnw test -Psolid
-```
-To run the test suite with a specific target server:
-```shell
-./mvnw test -Psolid -Dtarget=ess
-./mvnw test -Psolid -Dtarget=css
 ```
 
 Using an IDE, you can also run a specific scenario by editing the TestScenarioRunner and then running it as you would any

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -6,11 +6,6 @@
     - https://github.com/solid/conformance-test-harness/example/web-access-control/web-access-control-test-manifest.ttl
     - https://solidproject.org/TR/protocol
     - https://github.com/solid/conformance-test-harness/example/web-access-control/web-access-control-spec.ttl
-  target: https://github.com/solid/conformance-test-harness/ess
-#  target: https://github.com/solid/conformance-test-harness/ess-wac
-#  target: https://github.com/solid/conformance-test-harness/css
-#  target: https://github.com/solid/conformance-test-harness/nss
-#  target: https://github.com/solid/conformance-test-harness/trinpod
 
   # mapping feature URIs
   mappings:

--- a/config/test-subjects.ttl
+++ b/config/test-subjects.ttl
@@ -1,86 +1,8 @@
-prefix test-harness: <https://github.com/solid/conformance-test-harness/>
 prefix solid-test: <https://github.com/solid/conformance-test-harness/vocab#>
-
-prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-prefix xsd: <http://www.w3.org/2001/XMLSchema#>
 prefix doap: <http://usefulinc.com/ns/doap#>
 prefix earl: <http://www.w3.org/ns/earl#>
-prefix solid: <http://www.w3.org/ns/solid/terms#>
-prefix dcterms: <http://purl.org/dc/terms/>
 
-<ess>
+<target>
     a earl:Software, earl:TestSubject ;
-    doap:name "Enterprise Solid Server (ACP version)"@en ;
-    doap:release <ess#test-subject-release> ;
-    doap:developer <https://inrupt.com/profile/card/#us> ;
-    doap:homepage <https://inrupt.com/products/enterprise-solid-server> ;
-    doap:description "A production-grade Solid server produced and supported by Inrupt."@en ;
-    doap:programming-language "Java"@en ;
-    solid-test:features "authentication", "acl". #, "wac-allow"
-
-<ess#test-subject-release>
-    doap:name "ESS 1.1.6"@en;
-    doap:revision "1.1.6"@en;
-    doap:created "2021-09-11"^^xsd:date .
-
-<ess-wac>
-    a earl:Software, earl:TestSubject ;
-    doap:name "Enterprise Solid Server (Web Access Control version)"@en ;
-    doap:release <ess-wac#test-subject-release> ;
-    doap:developer <https://inrupt.com/profile/card/#us> ;
-    doap:homepage <https://inrupt.com/products/enterprise-solid-server> ;
-    doap:description "A production-grade Solid server produced and supported by Inrupt."@en ;
-    doap:programming-language "Java"@en ;
-    solid-test:features "authentication", "acl", "wac-allow".
-
-<ess-wac#test-subject-release>
-    doap:name "ESS 1.1.6"@en;
-    doap:revision "1.1.6"@en;
-    doap:created "2021-09-11"^^xsd:date .
-
-<css>
-    a earl:Software, earl:TestSubject ;
-    doap:name "Community Solid Server"@en ;
-    doap:release <css#test-subject-release> ;
-    doap:developer <https://github.com/solid> ;
-    doap:homepage <https://github.com/solid/community-server> ;
-    doap:description "An open and modular implementation of the Solid specifications."@en ;
-    doap:programming-language "TypeScript"@en ;
-    solid-test:features "authentication", "acl", "wac-allow", "wac" .
-
-<css#test-subject-release>
-    doap:name "CSS 1.1.0"@en ;
-    doap:revision "1.1.0"@en ;
-    doap:created "2021-09-03"^^xsd:date .
-
-<nss>
-    a earl:Software, earl:TestSubject ;
-    doap:name "Node Solid Server"@en ;
-    doap:release <nss#test-subject-release> ;
-    doap:developer <https://github.com/solid> ;
-    doap:homepage <https://github.com/solid/node-solid-server> ;
-    doap:description "Solid server on top of the file-system in NodeJS."@en ;
-    doap:programming-language "JavaScript"@en ;
-    solid-test:features "authentication", "acl", "wac-allow", "wac" .
-
-<nss#test-subject-release>
-    doap:name "NSS 5.6.8"@en ;
-    doap:revision "5.6.8"@en ;
-    doap:created "2021-07-22"^^xsd:date .
-
-<trinpod>
-    a earl:Software, earl:TestSubject ;
-    doap:name "TrinPod"@en ;
-    doap:release <trinpod#test-subject-release> ;
-    doap:developer <https://graphmetrix.com> ;
-    doap:homepage <https://graphmetrix.com/trinpod> ;
-    doap:description
-        "TrinPod™ is an Industrial strength Solid Pod with conceptual computing through Trinity AI Capable of handling a massive amount of data."@en ;
-    doap:programming-language "Common Lisp"@en ;
-    solid-test:features "authentication", "acl", "wac-allow", "wac" .
-
-<trinpod#test-subject-release>
-    doap:name "TrinPod-Server"@en ;
-    doap:revision "2.3.3"@en ;
-    doap:created "2021-10-14"^^xsd:date .
+    doap:name "Test Subject"@en ;
+    solid-test:features "authentication", "acl". #, "wac-allow", "acp-legacy"

--- a/src/main/docker/application.yaml
+++ b/src/main/docker/application.yaml
@@ -5,7 +5,6 @@ sources:
   - https://solidproject.org/TR/protocol
   - https://github.com/solid/specification-tests/web-access-control/web-access-control-spec.ttl
 #  - https://github.com/solid/specification-tests/protocol/converted.ttl
-target: https://github.com/solid/conformance-test-harness/ess
 mappings:
   - prefix: https://github.com/solid/specification-tests/
     path: /data

--- a/src/main/java/org/solid/testharness/ConformanceTestHarness.java
+++ b/src/main/java/org/solid/testharness/ConformanceTestHarness.java
@@ -221,7 +221,7 @@ public class ConformanceTestHarness {
 
     private void setupTestHarness(final Map<String, Boolean> features) {
         logger.info("===================== REGISTER CLIENTS ========================");
-        logger.info("Test subject: {}", config.getServerRoot());
+        logger.info("Test subject root: {}", config.getServerRoot());
         if (config.getUserRegistrationEndpoint() != null) {
             registerUsers();
         }

--- a/src/main/java/org/solid/testharness/config/TestSubject.java
+++ b/src/main/java/org/solid/testharness/config/TestSubject.java
@@ -95,7 +95,7 @@ public class TestSubject {
             }
             targetServer = new TargetServer(testSubject);
             dataRepository.setTestSubject(testSubject);
-            logger.debug("TestSubject {}", targetServer.getSubject());
+            logger.info("TestSubject {}", targetServer.getSubject());
         } catch (IOException e) {
             throw (TestHarnessInitializationException) new TestHarnessInitializationException(
                     "Failed to read config file %s: %s",


### PR DESCRIPTION
Following the previous suggestion to remove unnecessary server specific config.