### PR TITLE
Improve exception handling in API layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 * Extract Karate-facing API from internals of CTH.
+* Improve exception handling for reporting better errors in tests and simplifing tests.
 
 ### Minor changes
 * Improve error handling & reporting when running tests locally.

--- a/example/protocol/content-negotiation/content-negotiation-jsonld.feature
+++ b/example/protocol/content-negotiation/content-negotiation-jsonld.feature
@@ -4,7 +4,6 @@ Feature: Requests support content negotiation for JSON-LD resource
     * def testContainer = rootTestContainer.reserveContainer()
     * def exampleJson = karate.readAsString('../fixtures/example.json')
     * def resource = testContainer.createResource('.json', exampleJson, 'application/ld+json');
-    * assert resource.exists()
     * def expected = RDFUtils.jsonLdToTripleArray(exampleJson, resource.url)
     * headers clients.alice.getAuthHeaders('GET', resource.url)
     * url resource.url

--- a/example/protocol/content-negotiation/content-negotiation-turtle.feature
+++ b/example/protocol/content-negotiation/content-negotiation-turtle.feature
@@ -4,7 +4,6 @@ Feature: Requests support content negotiation for Turtle resource
     * def testContainer = rootTestContainer.reserveContainer()
     * def exampleTurtle = karate.readAsString('../fixtures/example.ttl')
     * def resource = testContainer.createResource('.ttl', exampleTurtle, 'text/turtle');
-#    * assert resource.exists()
     * def expected = RDFUtils.turtleToTripleArray(exampleTurtle, 'http://example.org/')
     * headers clients.alice.getAuthHeaders('GET', resource.url)
     * url resource.url

--- a/example/protocol/wac-allow/access-Bob-W-public-RA.feature
+++ b/example/protocol/wac-allow/access-Bob-W-public-RA.feature
@@ -6,20 +6,16 @@ Feature: The WAC-Allow header shows user and public access modes with Bob write 
       function() {
         const testContainer = rootTestContainer.reserveContainer();
         const resource = testContainer.createResource('.ttl', karate.readAsString('../fixtures/example.ttl'), 'text/turtle');
-        if (resource.exists()) {
-          const access = resource.accessDatasetBuilder
-                .setAgentAccess(resource.url, webIds.bob, ['write'])
-                .setPublicAccess(resource.url, ['read', 'append'])
-                .build();
-          resource.setAccessDataset(access);
-        }
+        const access = resource.accessDatasetBuilder
+              .setAgentAccess(resource.url, webIds.bob, ['write'])
+              .setPublicAccess(resource.url, ['read', 'append'])
+              .build();
+        resource.accessDataset = access;
         return resource;
       }
     """
     * def resource = callonce setup
-    * assert resource.exists()
-    * def resourceUrl = resource.url
-    * url resourceUrl
+    * url resource.url
 
   Scenario: There is an acl on the resource containing Bob's WebID
     Given url resource.aclUrl
@@ -41,7 +37,7 @@ Feature: The WAC-Allow header shows user and public access modes with Bob write 
     Then status 404
 
   Scenario: Bob calls GET and the header shows RWA access for user, RA for public
-    Given headers clients.bob.getAuthHeaders('GET', resourceUrl)
+    Given headers clients.bob.getAuthHeaders('GET', resource.url)
     When method GET
     Then status 200
     And match header WAC-Allow != null
@@ -50,7 +46,7 @@ Feature: The WAC-Allow header shows user and public access modes with Bob write 
     And match result.public contains only ['read', 'append']
 
   Scenario: Bob calls HEAD and the header shows RWA access for user, RA for public
-    Given headers clients.bob.getAuthHeaders('HEAD', resourceUrl)
+    Given headers clients.bob.getAuthHeaders('HEAD', resource.url)
     When method HEAD
     Then status 200
     And match header WAC-Allow != null

--- a/example/protocol/wac-allow/access-public-R.feature
+++ b/example/protocol/wac-allow/access-public-R.feature
@@ -6,19 +6,15 @@ Feature: The WAC-Allow header shows user and public access modes with public rea
       function() {
         const testContainer = rootTestContainer.reserveContainer();
         const resource = testContainer.createResource('.ttl', karate.readAsString('../fixtures/example.ttl'), 'text/turtle');
-        if (resource.exists()) {
-          const access = resource.accessDatasetBuilder
-                .setPublicAccess(resource.url, ['read'])
-                .build();
-          resource.setAccessDataset(access);
-        }
+        const access = resource.accessDatasetBuilder
+              .setPublicAccess(resource.url, ['read'])
+              .build();
+        resource.accessDataset = access;
         return resource;
       }
     """
     * def resource = callonce setup
-    * assert resource.exists()
-    * def resourceUrl = resource.url
-    * url resourceUrl
+    * url resource.url
 
   Scenario: There is an acl on the resource granting public access
     Given url resource.aclUrl
@@ -39,7 +35,7 @@ Feature: The WAC-Allow header shows user and public access modes with public rea
     Then status 404
 
   Scenario: Bob calls GET and the header shows R access for user, R for public
-    Given headers clients.bob.getAuthHeaders('GET', resourceUrl)
+    Given headers clients.bob.getAuthHeaders('GET', resource.url)
     When method GET
     Then status 200
     And match header WAC-Allow != null
@@ -48,7 +44,7 @@ Feature: The WAC-Allow header shows user and public access modes with public rea
     And match result.public contains only ['read']
 
   Scenario: Bob calls HEAD and the header shows R access for user, R for public
-    Given headers clients.bob.getAuthHeaders('HEAD', resourceUrl)
+    Given headers clients.bob.getAuthHeaders('HEAD', resource.url)
     When method HEAD
     Then status 200
     And match header WAC-Allow != null

--- a/example/protocol/wac-allow/default-Bob-W-public-RA.feature
+++ b/example/protocol/wac-allow/default-Bob-W-public-RA.feature
@@ -6,20 +6,16 @@ Feature: The WAC-Allow header shows user and public access modes with Bob write 
       function() {
         const testContainer = rootTestContainer.reserveContainer();
         const resource = testContainer.createResource('.ttl', karate.readAsString('../fixtures/example.ttl'), 'text/turtle');
-        if (resource.exists()) {
-          const access = testContainer.accessDatasetBuilder
-                .setInheritableAgentAccess(testContainer.url, webIds.bob, ['write'])
-                .setInheritablePublicAccess(testContainer.url, ['read', 'append'])
-                .build();
-          resource.container.setAccessDataset(access)
-        }
+        const access = testContainer.accessDatasetBuilder
+              .setInheritableAgentAccess(testContainer.url, webIds.bob, ['write'])
+              .setInheritablePublicAccess(testContainer.url, ['read', 'append'])
+              .build();
+        resource.container.accessDataset = access
         return resource;
       }
     """
     * def resource = callonce setup
-    * assert resource.exists()
-    * def resourceUrl = resource.url
-    * url resourceUrl
+    * url resource.url
 
   Scenario: There is no acl on the resource
     Given url resource.aclUrl
@@ -38,7 +34,7 @@ Feature: The WAC-Allow header shows user and public access modes with Bob write 
     And match response contains webIds.bob
 
   Scenario: Bob calls GET and the header shows RWA access for user, RA for public
-    Given headers clients.bob.getAuthHeaders('GET', resourceUrl)
+    Given headers clients.bob.getAuthHeaders('GET', resource.url)
     When method GET
     Then status 200
     And match header WAC-Allow != null
@@ -47,7 +43,7 @@ Feature: The WAC-Allow header shows user and public access modes with Bob write 
     And match result.public contains only ['read', 'append']
 
   Scenario: Bob calls HEAD and the header shows RWA access for user, RA for public
-    Given headers clients.bob.getAuthHeaders('HEAD', resourceUrl)
+    Given headers clients.bob.getAuthHeaders('HEAD', resource.url)
     When method HEAD
     Then status 200
     And match header WAC-Allow != null

--- a/example/web-access-control/acl-object/container-access-to-default.feature
+++ b/example/web-access-control/acl-object/container-access-to-default.feature
@@ -9,20 +9,17 @@ Feature: Bob can read a container and its children if he is granted both direct 
                 .setAgentAccess(testContainer.url, webIds.bob, ['read'])
                 .setInheritableAgentAccess(testContainer.url, webIds.bob, ['read'])
                 .build();
-        if (testContainer.setAccessDataset(access)) {
-          const intermediateContainer = testContainer.reserveContainer();
-          const resource = intermediateContainer.createResource('.txt', 'hello', 'text/plain')
-          return {
-            containerUrl: testContainer.url,
-            intermediateContainerUrl: intermediateContainer.url,
-            resourceUrl: resource.url
-          }
+        testContainer.accessDataset = access;
+        const intermediateContainer = testContainer.reserveContainer();
+        const resource = intermediateContainer.createResource('.txt', 'hello', 'text/plain')
+        return {
+          containerUrl: testContainer.url,
+          intermediateContainerUrl: intermediateContainer.url,
+          resourceUrl: resource.url
         }
-        return null;
       }
     """
     * def test = callonce setup
-    * assert test != null
 
   Scenario: Bob can read the container and its children
     Given url test.containerUrl

--- a/example/web-access-control/acl-object/container-access-to.feature
+++ b/example/web-access-control/acl-object/container-access-to.feature
@@ -8,20 +8,17 @@ Feature: Bob can not read child containers/resources of a container to which he 
         const access = testContainer.accessDatasetBuilder
                 .setAgentAccess(testContainer.url, webIds.bob, ['read'])
                 .build();
-        if (testContainer.setAccessDataset(access)) {
-          const intermediateContainer = testContainer.reserveContainer();
-          const resource = intermediateContainer.createResource('.txt', 'hello', 'text/plain')
-          return {
-            containerUrl: testContainer.url,
-            intermediateContainerUrl: intermediateContainer.url,
-            resourceUrl: resource.url
-          }
+        testContainer.accessDataset = access;
+        const intermediateContainer = testContainer.reserveContainer();
+        const resource = intermediateContainer.createResource('.txt', 'hello', 'text/plain')
+        return {
+          containerUrl: testContainer.url,
+          intermediateContainerUrl: intermediateContainer.url,
+          resourceUrl: resource.url
         }
-        return null;
       }
     """
     * def test = callonce setup
-    * assert test != null
 
   Scenario: Bob can only read the container
     Given url test.containerUrl

--- a/example/web-access-control/acl-object/container-default.feature
+++ b/example/web-access-control/acl-object/container-default.feature
@@ -8,20 +8,17 @@ Feature: Bob can only read child containers/resources of a container to which he
         const access = testContainer.accessDatasetBuilder
                 .setInheritableAgentAccess(testContainer.url, webIds.bob, ['read'])
                 .build();
-        if (testContainer.setAccessDataset(access)) {
-          const intermediateContainer = testContainer.reserveContainer();
-          const resource = intermediateContainer.createResource('.txt', 'hello', 'text/plain')
-          return {
-            containerUrl: testContainer.url,
-            intermediateContainerUrl: intermediateContainer.url,
-            resourceUrl: resource.url
-          }
+        testContainer.accessDataset = access;
+        const intermediateContainer = testContainer.reserveContainer();
+        const resource = intermediateContainer.createResource('.txt', 'hello', 'text/plain')
+        return {
+          containerUrl: testContainer.url,
+          intermediateContainerUrl: intermediateContainer.url,
+          resourceUrl: resource.url
         }
-        return null;
       }
     """
     * def test = callonce setup
-    * assert test != null
 
   Scenario: Bob can only read resources inside the container
     Given url test.containerUrl

--- a/example/web-access-control/acl-object/container-none.feature
+++ b/example/web-access-control/acl-object/container-none.feature
@@ -6,20 +6,17 @@ Feature: Bob cannot read a container or children if he is not given any access
       function() {
         const testContainer = rootTestContainer.createContainer();
         const access = testContainer.accessDatasetBuilder.build();
-        if (testContainer.setAccessDataset(access)) {
-          const intermediateContainer = testContainer.reserveContainer();
-          const resource = intermediateContainer.createResource('.txt', 'hello', 'text/plain')
-          return {
-            containerUrl: testContainer.url,
-            intermediateContainerUrl: intermediateContainer.url,
-            resourceUrl: resource.url
-          }
+        testContainer.accessDataset = access
+        const intermediateContainer = testContainer.reserveContainer();
+        const resource = intermediateContainer.createResource('.txt', 'hello', 'text/plain')
+        return {
+          containerUrl: testContainer.url,
+          intermediateContainerUrl: intermediateContainer.url,
+          resourceUrl: resource.url
         }
-        return null;
       }
     """
     * def test = callonce setup
-    * assert test != null
 
   Scenario: Bob cannot read the container or its children
     Given url test.containerUrl

--- a/example/web-access-control/protected-operation/acl-propagation.feature
+++ b/example/web-access-control/protected-operation/acl-propagation.feature
@@ -3,7 +3,6 @@ Feature: Inheritable ACL controls child resources
   Background: Create test resource and prepare ACL
     * def testContainer = rootTestContainer.reserveContainer()
     * def resource = testContainer.createResource('.ttl', karate.readAsString('../fixtures/example.ttl'), 'text/turtle');
-    * assert resource.exists()
 
   Scenario: Check Bob's access before and after setting access via the parent ACL
     # Bob cannot access the resource

--- a/example/web-access-control/protected-operation/debug-direct-acl.feature
+++ b/example/web-access-control/protected-operation/debug-direct-acl.feature
@@ -15,7 +15,7 @@ Feature: Test ACL creation in apply mode
 
     # grant Bob read access
     * def access = testResource.accessDatasetBuilder.setAgentAccess(testResource.url, webIds.bob, ['read']).build()
-    * assert testResource.setAccessDataset(access)
+    * testResource.accessDataset = access
 
     # get the ACR to confirm it changed
     Given url testResource.aclUrl

--- a/example/web-access-control/protected-operation/debug-indirect-acl.feature
+++ b/example/web-access-control/protected-operation/debug-indirect-acl.feature
@@ -14,7 +14,7 @@ Feature: Test ACL in applyMembers mode
 
     # grant Bob read access to member resources
     * def access = testContainer.accessDatasetBuilder.setInheritableAgentAccess(testContainer.url, webIds.bob, ['read']).build()
-    * assert testContainer.setAccessDataset(access)
+    * testContainer.accessDataset = access
 
     # get the ACR to confirm it changed
     Given url testContainer.aclUrl
@@ -27,7 +27,6 @@ Feature: Test ACL in applyMembers mode
 
     # create a new resource in the container which should inherit access from the container
     * def testResource = testContainer.createResource('.ttl', karate.readAsString('../fixtures/example.ttl'), 'text/turtle');
-    * assert testResource.exists()
 
     # get the resource ACR to confirm it has inherited read permission for Bob
     Given url testResource.aclUrl

--- a/example/web-access-control/protected-operation/debug-retro-acl.feature
+++ b/example/web-access-control/protected-operation/debug-retro-acl.feature
@@ -21,7 +21,7 @@ Feature: Test ACL in applyMembers mode retrospectively applied
 
     # grant Bob read access to member resources
     * def access = testContainer.accessDatasetBuilder.setInheritableAgentAccess(testContainer.url, webIds.bob, ['read']).build()
-    * assert testContainer.setAccessDataset(access)
+    * testContainer.accessDataset = access
 
     # get the container ACR to confirm it changed
     Given url testContainer.aclUrl

--- a/example/web-access-control/protected-operation/not-read-resource-access-AWC.feature
+++ b/example/web-access-control/protected-operation/not-read-resource-access-AWC.feature
@@ -6,26 +6,22 @@ Feature: Bob cannot read an RDF resource to which he is not granted read access
       function() {
         const testContainer = rootTestContainer.reserveContainer();
         const resource = testContainer.createResource('.ttl', karate.readAsString('../fixtures/example.ttl'), 'text/turtle');
-        if (resource.exists()) {
-          const access = resource.accessDatasetBuilder
-            .setAgentAccess(resource.url, webIds.bob, ['append', 'write', 'control'])
-            .build();
-          resource.setAccessDataset(access);
-        }
+        const access = resource.accessDatasetBuilder
+          .setAgentAccess(resource.url, webIds.bob, ['append', 'write', 'control'])
+          .build();
+        resource.accessDataset = access;
         return resource;
       }
     """
     * def resource = callonce setup
-    * assert resource.exists()
-    * def resourceUrl = resource.url
-    * url resourceUrl
+    * url resource.url
 
   Scenario: Bob cannot read the resource with GET
-    Given headers clients.bob.getAuthHeaders('GET', resourceUrl)
+    Given headers clients.bob.getAuthHeaders('GET', resource.url)
     When method GET
     Then status 403
 
   Scenario: Bob cannot read the resource with HEAD
-    Given headers clients.bob.getAuthHeaders('HEAD', resourceUrl)
+    Given headers clients.bob.getAuthHeaders('HEAD', resource.url)
     When method HEAD
     Then status 403

--- a/example/web-access-control/protected-operation/not-read-resource-default-AWC.feature
+++ b/example/web-access-control/protected-operation/not-read-resource-default-AWC.feature
@@ -9,28 +9,26 @@ Feature: Bob cannot read an RDF resource to which he is not granted default read
           .setAgentAccess(testContainer.url, webIds.bob, ['write'])
           .setInheritableAgentAccess(testContainer.url, webIds.bob, ['append', 'write', 'control'])
           .build();
-        testContainer.setAccessDataset(access);
+        testContainer.accessDataset = access;
         return testContainer.createResource('.ttl', karate.readAsString('../fixtures/example.ttl'), 'text/turtle');
       }
     """
     * def resource = callonce setup
-    * assert resource.exists()
-    * def resourceUrl = resource.url
-    * url resourceUrl
+    * url resource.url
 
   Scenario: Bob cannot read the resource with GET
-    Given headers clients.bob.getAuthHeaders('GET', resourceUrl)
+    Given headers clients.bob.getAuthHeaders('GET', resource.url)
     When method GET
     Then status 403
 
   Scenario: Bob cannot read the resource with HEAD
-    Given headers clients.bob.getAuthHeaders('HEAD', resourceUrl)
+    Given headers clients.bob.getAuthHeaders('HEAD', resource.url)
     When method HEAD
     Then status 403
 
   Scenario: Bob can PUT to the resource but gets nothing back since he cannot read
     Given request '<> <http://www.w3.org/2000/01/rdf-schema#comment> "Bob replaced it." .'
-    And headers clients.bob.getAuthHeaders('PUT', resourceUrl)
+    And headers clients.bob.getAuthHeaders('PUT', resource.url)
     And header Content-Type = 'text/turtle'
     When method PUT
     Then status 204

--- a/example/web-access-control/protected-operation/read-resource-access-R.feature
+++ b/example/web-access-control/protected-operation/read-resource-access-R.feature
@@ -6,53 +6,49 @@ Feature: Bob can only read an RDF resource to which he is only granted read acce
       function() {
         const testContainer = rootTestContainer.reserveContainer();
         const resource = testContainer.createResource('.ttl', karate.readAsString('../fixtures/example.ttl'), 'text/turtle');
-        if (resource.exists()) {
-          const access = resource.accessDatasetBuilder
-            .setAgentAccess(resource.url, webIds.bob, ['read'])
-            .build();
-          resource.setAccessDataset(access);
-        }
+        const access = resource.accessDatasetBuilder
+          .setAgentAccess(resource.url, webIds.bob, ['read'])
+          .build();
+        resource.accessDataset = access;
         return resource;
       }
     """
     * def resource = callonce setup
-    * assert resource.exists()
-    * def resourceUrl = resource.url
-    * url resourceUrl
+    * url resource.url
 
   Scenario: Bob can read the resource with GET
-    Given headers clients.bob.getAuthHeaders('GET', resourceUrl)
+    Given headers clients.bob.getAuthHeaders('GET', resource.url)
     When method GET
     Then status 200
 
   Scenario: Bob can read the resource with HEAD
-    Given headers clients.bob.getAuthHeaders('HEAD', resourceUrl)
+    Given headers clients.bob.getAuthHeaders('HEAD', resource.url)
     When method HEAD
     Then status 200
 
   Scenario: Bob cannot PUT to the resource
     Given request '<> <http://www.w3.org/2000/01/rdf-schema#comment> "Bob replaced it." .'
-    And headers clients.bob.getAuthHeaders('PUT', resourceUrl)
+    And headers clients.bob.getAuthHeaders('PUT', resource.url)
     And header Content-Type = 'text/turtle'
     When method PUT
     Then status 403
 
   Scenario: Bob cannot PATCH the resource
     Given request 'INSERT DATA { <> a <http://example.org/Foo> . }'
-    And headers clients.bob.getAuthHeaders('PATCH', resourceUrl)
+    And headers clients.bob.getAuthHeaders('PATCH', resource.url)
     And header Content-Type = 'application/sparql-update'
     When method PATCH
     Then status 403
 
   Scenario: Bob cannot POST to the resource
     Given request '<> <http://www.w3.org/2000/01/rdf-schema#comment> "Bob replaced it." .'
-    And headers clients.bob.getAuthHeaders('POST', resourceUrl)
+    And headers clients.bob.getAuthHeaders('POST', resource.url)
     And header Content-Type = 'text/turtle'
     When method POST
     Then status 403
 
   Scenario: Bob cannot DELETE the resource
-    Given headers clients.bob.getAuthHeaders('DELETE', resourceUrl)
+    Given headers clients.bob.getAuthHeaders('DELETE', resource.url)
     When method DELETE
     Then status 403
 

--- a/example/web-access-control/protected-operation/read-resource-default-R.feature
+++ b/example/web-access-control/protected-operation/read-resource-default-R.feature
@@ -8,47 +8,45 @@ Feature: Bob can only read an RDF resource to which he is only granted default r
         const access = testContainer.accessDatasetBuilder
               .setInheritableAgentAccess(testContainer.url, webIds.bob, ['read'])
               .build();
-        testContainer.setAccessDataset(access);
+        testContainer.accessDataset = access;
         return testContainer.createResource('.ttl', karate.readAsString('../fixtures/example.ttl'), 'text/turtle');
       }
     """
     * def resource = callonce setup
-    * assert resource.exists()
-    * def resourceUrl = resource.url
-    * url resourceUrl
+    * url resource.url
 
   Scenario: Bob can read the resource with GET
-    Given headers clients.bob.getAuthHeaders('GET', resourceUrl)
+    Given headers clients.bob.getAuthHeaders('GET', resource.url)
     When method GET
     Then status 200
 
   Scenario: Bob can read the resource with HEAD
-    Given headers clients.bob.getAuthHeaders('HEAD', resourceUrl)
+    Given headers clients.bob.getAuthHeaders('HEAD', resource.url)
     When method HEAD
     Then status 200
 
   Scenario: Bob cannot PUT to the resource
     Given request '<> <http://www.w3.org/2000/01/rdf-schema#comment> "Bob replaced it." .'
-    And headers clients.bob.getAuthHeaders('PUT', resourceUrl)
+    And headers clients.bob.getAuthHeaders('PUT', resource.url)
     And header Content-Type = 'text/turtle'
     When method PUT
     Then status 403
 
   Scenario: Bob cannot PATCH the resource
     Given request 'INSERT DATA { <> a <http://example.org/Foo> . }'
-    And headers clients.bob.getAuthHeaders('PATCH', resourceUrl)
+    And headers clients.bob.getAuthHeaders('PATCH', resource.url)
     And header Content-Type = 'application/sparql-update'
     When method PATCH
     Then status 403
 
   Scenario: Bob cannot POST to the resource
     Given request '<> <http://www.w3.org/2000/01/rdf-schema#comment> "Bob replaced it." .'
-    And headers clients.bob.getAuthHeaders('POST', resourceUrl)
+    And headers clients.bob.getAuthHeaders('POST', resource.url)
     And header Content-Type = 'text/turtle'
     When method POST
     Then status 403
 
   Scenario: Bob cannot DELETE the resource
-    Given headers clients.bob.getAuthHeaders('DELETE', resourceUrl)
+    Given headers clients.bob.getAuthHeaders('DELETE', resource.url)
     When method DELETE
     Then status 403

--- a/src/main/java/org/solid/testharness/accesscontrol/AccessDataset.java
+++ b/src/main/java/org/solid/testharness/accesscontrol/AccessDataset.java
@@ -63,7 +63,7 @@ public interface AccessDataset {
                 .set(BasicWriterSettings.INLINE_BLANK_NODES, true);
         Rio.write(getModel(), rdfWriter);
         return sw.toString();
-    };
+    }
 
     default String asSparqlInsert() {
         if (getModel() == null) {
@@ -85,7 +85,7 @@ public interface AccessDataset {
         sw.append("}");
         // modify the prefixes to be SPARQL format
         return sw.toString().replaceAll("@prefix ([^:]+): <([^>]+)> .", "PREFIX $1: <$2>");
-    };
+    }
 
     default void parseTurtle(String data, String baseUri) throws IOException {
         final Model model = Rio.parse(new StringReader(data), baseUri, RDFFormat.TURTLE);
@@ -99,5 +99,5 @@ public interface AccessDataset {
         return Models.isSubset(getModel(), otherAccessDataset.getModel());
     }
 
-    boolean apply(Client client, URI uri) throws IOException, InterruptedException;
+    void apply(Client client, URI uri) throws Exception;
 }

--- a/src/main/java/org/solid/testharness/accesscontrol/AccessDatasetAcp.java
+++ b/src/main/java/org/solid/testharness/accesscontrol/AccessDatasetAcp.java
@@ -103,7 +103,7 @@ public class AccessDatasetAcp implements AccessDataset {
                             .add(accessPolicyNode, RDF.type, ACP.Policy)
                             .add(accessPolicyNode, ACP.allOf, ruleNode);
                     controlAccessModes.stream()
-                            .map(mode -> standardModes.get(mode))
+                            .map(standardModes::get)
                             .forEach(mode -> builder.add(accessPolicyNode, ACP.allow, mode));
                 }
                 // Jacoco does not report switch coverage correctly
@@ -158,11 +158,14 @@ public class AccessDatasetAcp implements AccessDataset {
     }
 
     @Override
-    public boolean apply(final Client client, final URI uri) throws IOException, InterruptedException {
-        if (model == null) return true;
-        final HttpResponse<String> response = client.patch(uri, asSparqlInsert(),
-                HttpConstants.MEDIA_TYPE_APPLICATION_SPARQL_UPDATE);
-        return HttpUtils.isSuccessful(response.statusCode());
+    public void apply(final Client client, final URI uri) throws Exception {
+        if (model != null) {
+            final HttpResponse<String> response = client.patch(uri, asSparqlInsert(),
+                    HttpConstants.MEDIA_TYPE_APPLICATION_SPARQL_UPDATE);
+            if (!HttpUtils.isSuccessful(response.statusCode())) {
+                throw new Exception("Error response=" + response.statusCode() + " trying to apply ACL");
+            }
+        }
     }
 
     @Override

--- a/src/main/java/org/solid/testharness/accesscontrol/AccessDatasetAcpLegacy.java
+++ b/src/main/java/org/solid/testharness/accesscontrol/AccessDatasetAcpLegacy.java
@@ -96,7 +96,7 @@ public class AccessDatasetAcpLegacy implements AccessDataset {
                             .add(accessPolicyNode, RDF.type, ACP.Policy)
                             .add(accessPolicyNode, ACP.allOf, ruleNode);
                     controlAccessModes.stream()
-                            .map(mode -> standardModes.get(mode))
+                            .map(standardModes::get)
                             .forEach(mode -> builder.add(accessPolicyNode, ACP.allow, mode));
                 }
                 // Jacoco does not report switch coverage correctly
@@ -151,11 +151,14 @@ public class AccessDatasetAcpLegacy implements AccessDataset {
     }
 
     @Override
-    public boolean apply(final Client client, final URI uri) throws IOException, InterruptedException {
-        if (model == null) return true;
-        final HttpResponse<String> response = client.patch(uri, asSparqlInsert(),
-                HttpConstants.MEDIA_TYPE_APPLICATION_SPARQL_UPDATE);
-        return HttpUtils.isSuccessful(response.statusCode());
+    public void apply(final Client client, final URI uri) throws Exception {
+        if (model != null) {
+            final HttpResponse<String> response = client.patch(uri, asSparqlInsert(),
+                    HttpConstants.MEDIA_TYPE_APPLICATION_SPARQL_UPDATE);
+            if (!HttpUtils.isSuccessful(response.statusCode())) {
+                throw new Exception("Error response=" + response.statusCode() + " trying to apply ACL");
+            }
+        }
     }
 
     @Override

--- a/src/main/java/org/solid/testharness/accesscontrol/AccessDatasetWac.java
+++ b/src/main/java/org/solid/testharness/accesscontrol/AccessDatasetWac.java
@@ -113,11 +113,14 @@ public class AccessDatasetWac implements AccessDataset {
     }
 
     @Override
-    public boolean apply(final Client client, final URI uri) throws IOException, InterruptedException {
-        if (model == null) return true;
-        final HttpResponse<Void> response = client.put(uri, asTurtle(),
-                HttpConstants.MEDIA_TYPE_TEXT_TURTLE);
-        return HttpUtils.isSuccessful(response.statusCode());
+    public void apply(final Client client, final URI uri) throws Exception {
+        if (model != null) {
+            final HttpResponse<Void> response = client.put(uri, asTurtle(),
+                    HttpConstants.MEDIA_TYPE_TEXT_TURTLE);
+            if (!HttpUtils.isSuccessful(response.statusCode())) {
+                throw new Exception("Error response=" + response.statusCode() + " trying to apply ACL");
+            }
+        }
     }
 
     @Override

--- a/src/main/java/org/solid/testharness/api/SolidClient.java
+++ b/src/main/java/org/solid/testharness/api/SolidClient.java
@@ -51,6 +51,10 @@ public class SolidClient {
      * @return the headers to be added to the HTTP request
      */
     public Map<String, String> getAuthHeaders(final String method, final String uri) {
-        return solidClientProvider.getClient().getAuthHeaders(method, URI.create(uri));
+        try {
+            return solidClientProvider.getClient().getAuthHeaders(method, URI.create(uri));
+        } catch (Exception e) {
+            throw new TestHarnessException("Failed to prepare auth headers", e);
+        }
     }
 }

--- a/src/main/java/org/solid/testharness/api/SolidContainer.java
+++ b/src/main/java/org/solid/testharness/api/SolidContainer.java
@@ -52,9 +52,13 @@ public final class SolidContainer extends SolidResource {
      * @return the container
      */
     public static SolidContainer create(final SolidClient solidClient, final String url) {
-        return new SolidContainer(
-                new SolidContainerProvider(solidClient.solidClientProvider, URI.create(url))
-        );
+        try {
+            return new SolidContainer(
+                    new SolidContainerProvider(solidClient.solidClientProvider, URI.create(url))
+            );
+        } catch (Exception e) {
+            throw new TestHarnessException("Failed to construct container", e);
+        }
     }
 
     /**
@@ -62,8 +66,12 @@ public final class SolidContainer extends SolidResource {
      * @return the container
      */
     public SolidContainer instantiate() {
-        solidContainerProvider.instantiate();
-        return this;
+        try {
+            solidContainerProvider.instantiate();
+            return this;
+        } catch (Exception e) {
+            throw new TestHarnessException("Failed to instantiate container", e);
+        }
     }
 
     /**
@@ -71,15 +79,24 @@ public final class SolidContainer extends SolidResource {
      * @return the new container
      */
     public SolidContainer reserveContainer() {
-        return new SolidContainer(solidContainerProvider.reserveContainer(UUID.randomUUID().toString()));
+        try {
+            return new SolidContainer(solidContainerProvider.reserveContainer(UUID.randomUUID().toString()));
+        } catch (Exception e) {
+            throw new TestHarnessException("Failed to reserve container", e);
+        }
     }
 
     /**
      * Create a new container as a child of this one using a random name.
      * @return the new container
      */
-    public SolidContainer createContainer() {
-        return new SolidContainer(solidContainerProvider.reserveContainer(UUID.randomUUID().toString()).instantiate());
+    public SolidContainer createContainer() throws TestHarnessException {
+        try {
+            return new SolidContainer(solidContainerProvider.reserveContainer(UUID.randomUUID().toString())
+                    .instantiate());
+        } catch (Exception e) {
+            throw new TestHarnessException("Failed to create container", e);
+        }
     }
 
     /**
@@ -88,7 +105,11 @@ public final class SolidContainer extends SolidResource {
      * @return the new resource
      */
     public SolidResource reserveResource(final String suffix) {
-        return new SolidResource(solidContainerProvider.reserveResource(UUID.randomUUID() + suffix));
+        try {
+            return new SolidResource(solidContainerProvider.reserveResource(UUID.randomUUID() + suffix));
+        } catch (Exception e) {
+            throw new TestHarnessException("Failed to reserve resource", e);
+        }
     }
 
     /**
@@ -100,16 +121,23 @@ public final class SolidContainer extends SolidResource {
      * @return the new resource
      */
     public SolidResource createResource(final String suffix, final String body, final String type) {
-        return new SolidResource(solidContainerProvider.createResource(UUID.randomUUID() + suffix, body, type));
+        try {
+            return new SolidResource(solidContainerProvider.createResource(UUID.randomUUID() + suffix, body, type));
+        } catch (Exception e) {
+            throw new TestHarnessException("Failed to create resource", e);
+        }
     }
 
     /**
      * Get a list of the members of this container.
      * @return a list of members
-     * @throws Exception
      */
-    public List<String> listMembers() throws Exception {
-        return RDFUtils.parseContainerContents(solidContainerProvider.getContentAsTurtle(), getUrl());
+    public List<String> listMembers() {
+        try {
+            return RDFUtils.parseContainerContents(solidContainerProvider.getContentAsTurtle(), getUrl());
+        } catch (Exception e) {
+            throw new TestHarnessException("Failed to get container member listing", e);
+        }
     }
 
     /**
@@ -117,18 +145,24 @@ public final class SolidContainer extends SolidResource {
      * Given container contents, parse to extract the list of members.
      * @param data The contents of this resource in Turtle format
      * @return a list of members
-     * @throws Exception
      */
     @Deprecated
-    public List<String> parseMembers(final String data) throws Exception {
-        return RDFUtils.parseContainerContents(data, getUrl());
+    public List<String> parseMembers(final String data) {
+        try {
+            return RDFUtils.parseContainerContents(data, getUrl());
+        } catch (Exception e) {
+            throw new TestHarnessException("Failed to parse container contents", e);
+        }
     }
 
     /**
      * Delete the contents of this container and any of their contents recursively but leave this container.
-     * @throws Exception
      */
-    public void deleteContents() throws Exception {
-        solidContainerProvider.deleteContents();
+    public void deleteContents() {
+        try {
+            solidContainerProvider.deleteContents();
+        } catch (Exception e) {
+            throw new TestHarnessException("Failed to delete container contents", e);
+        }
     }
 }

--- a/src/main/java/org/solid/testharness/api/SolidResource.java
+++ b/src/main/java/org/solid/testharness/api/SolidResource.java
@@ -56,9 +56,13 @@ public class SolidResource {
      */
     public static SolidResource create(final SolidClient solidClient, final String url,
                                        final String body, final String type) {
-        return new SolidResource(
-                new SolidResourceProvider(solidClient.solidClientProvider, URI.create(url),body, type)
-        );
+        try {
+            return new SolidResource(
+                    new SolidResourceProvider(solidClient.solidClientProvider, URI.create(url),body, type)
+            );
+        } catch (Exception e) {
+            throw new TestHarnessException("Failed to construct resource", e);
+        }
     }
 
     /**
@@ -75,7 +79,8 @@ public class SolidResource {
      * @return the url
      */
     public String getUrl() {
-        return solidResourceProvider.getUrl() != null ? solidResourceProvider.getUrl().toString() : null;
+        final URI url = solidResourceProvider.getUrl();
+        return url != null ? url.toString() : null;
     }
 
     /**
@@ -90,30 +95,39 @@ public class SolidResource {
     /**
      * Return the URL of the ACL related to this resource.
      * @return ACL url
-     * @throws Exception
      */
-    public String getAclUrl() throws Exception {
-        final URI aclUrl = solidResourceProvider.getAclUrl();
-        return aclUrl != null ? aclUrl.toString() : null;
+    public String getAclUrl() {
+        try {
+            final URI aclUrl = solidResourceProvider.getAclUrl();
+            return aclUrl != null ? aclUrl.toString() : null;
+        } catch (Exception e) {
+            throw new TestHarnessException("Failed to get ACL url", e);
+        }
     }
 
     /**
      * Search up the path hierarchy to attempt to find the container which is marked as the storage for this resource.
      * @return the SolidResource representing the storage container for this resource, if found.
-     * @throws Exception
      */
-    public SolidResource findStorage() throws Exception {
-        final SolidResourceProvider storage = solidResourceProvider.findStorage();
-        return storage != null ? new SolidResource(storage) : null;
+    public SolidResource findStorage() {
+        try {
+            final SolidResourceProvider storage = solidResourceProvider.findStorage();
+            return storage != null ? new SolidResource(storage) : null;
+        } catch (Exception e) {
+            throw new TestHarnessException("Failed to find storage for this resource", e);
+        }
     }
 
     /**
      * Returns a boolean indicating if the resource is a storage root.
      * @return <code>true</code> if the resource has a <code>pim:Storage</code> link; <code>false</code> otherwise.
-     * @throws Exception
      */
-    public boolean isStorageType() throws Exception {
-        return solidResourceProvider.isStorageType();
+    public boolean isStorageType() {
+        try {
+            return solidResourceProvider.isStorageType();
+        } catch (Exception e) {
+            throw new TestHarnessException("Failed to find storage link header", e);
+        }
     }
 
     /**
@@ -121,47 +135,57 @@ public class SolidResource {
      * @deprecated Use <code>getAccessDatasetBuilder()</code> as the owner is the client who created the resource.
      * @param owner a WebId
      * @return an access dataset builder
-     * @throws Exception
      */
     @Deprecated
-    public AccessDatasetBuilder getAccessDatasetBuilder(final String owner) throws Exception {
+    public AccessDatasetBuilder getAccessDatasetBuilder(final String owner) {
         return getAccessDatasetBuilder();
     }
 
     /**
      * Return an <code>AccessDatasetBuilder</code>.
      * @return an access dataset builder
-     * @throws Exception
      */
-    public AccessDatasetBuilder getAccessDatasetBuilder() throws Exception {
-        return solidResourceProvider.getAccessDatasetBuilder();
+    public AccessDatasetBuilder getAccessDatasetBuilder() {
+        try {
+            return solidResourceProvider.getAccessDatasetBuilder();
+        } catch (Exception e) {
+            throw new TestHarnessException("Failed to create AccessDatasetBuilder", e);
+        }
     }
 
     /**
      * Return the <code>AccessDataset</code> associated with this resource.
      * @return an access dataset
-     * @throws Exception
      */
-    public AccessDataset getAccessDataset() throws Exception {
-        return solidResourceProvider.getAccessDataset();
+    public AccessDataset getAccessDataset() {
+        try {
+            return solidResourceProvider.getAccessDataset();
+        } catch (Exception e) {
+            throw new TestHarnessException("Failed to get the access dataset", e);
+        }
     }
 
     /**
      * Apply an <code>AccessDataset</code> to the resource.
      * @param accessDataset the <code>AccessDataset</code> to be applied to the resource
-     * @return <code>true</code> if this succeeds
-     * @throws Exception
      */
-    public boolean setAccessDataset(final AccessDataset accessDataset) throws Exception {
-        return solidResourceProvider.setAccessDataset(accessDataset);
+    public void setAccessDataset(final AccessDataset accessDataset) {
+        try {
+            solidResourceProvider.setAccessDataset(accessDataset);
+        } catch (Exception e) {
+            throw new TestHarnessException("Failed to apply the ACL", e);
+        }
     }
 
     /**
      * Delete this resource (and any contents if it is a container).
-     * @throws Exception
      */
-    public void delete() throws Exception {
-        solidResourceProvider.delete();
+    public void delete() {
+        try {
+            solidResourceProvider.delete();
+        } catch (Exception e) {
+            throw new TestHarnessException("Failed to delete the resource", e);
+        }
     }
 
     @Override

--- a/src/main/java/org/solid/testharness/api/TestHarnessException.java
+++ b/src/main/java/org/solid/testharness/api/TestHarnessException.java
@@ -21,18 +21,27 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.solid.testharness.utils;
+package org.solid.testharness.api;
 
-import java.util.Formatter;
+public class TestHarnessException extends RuntimeException {
+    private static final long serialVersionUID = -3676037765799217562L;
+    private String message;
 
-public class TestHarnessInitializationException extends RuntimeException {
-    private static final long serialVersionUID = -3676037765799217561L;
-
-    public TestHarnessInitializationException(final String message, final Throwable cause) {
+    public TestHarnessException(final String message, final Throwable cause) {
         super(message, cause);
+        this.message = message;
     }
 
-    public TestHarnessInitializationException(final String message, final String... args) {
-        super(args.length > 0 ? new Formatter().format(message, args).toString() : message);
+    @Override
+    public String getMessage() {
+        final StringBuilder sb = new StringBuilder();
+        sb.append(getClass().getName()).append(": ");
+        if (message != null) {
+            sb.append(message);
+        }
+        if (getCause() != null) {
+            sb.append("\nCaused by: ").append(getCause());
+        }
+        return sb.toString();
     }
 }

--- a/src/main/java/org/solid/testharness/config/TestSubject.java
+++ b/src/main/java/org/solid/testharness/config/TestSubject.java
@@ -153,7 +153,6 @@ public class TestSubject {
 
         if (config.isSetupRootAcl()) {
             logger.debug("Setup root acl");
-            final boolean success;
             try {
                 final SolidContainerProvider rootContainer = new SolidContainerProvider(solidClientProvider,
                         config.getServerRoot());
@@ -165,14 +164,11 @@ public class TestSubject {
                         .setInheritableAgentAccess(rootContainer.getUrl().toString(), alice, modes)
                         .build();
                 logger.info("ACL doc: {}", accessDataset.toString());
-                success = rootContainer.setAccessDataset(accessDataset);
+                rootContainer.setAccessDataset(accessDataset);
             } catch (Exception e) {
                 throw (TestHarnessInitializationException) new TestHarnessInitializationException(
                         "Failed to create root ACL: %s", e.toString()
                 ).initCause(e);
-            }
-            if (!success) {
-                throw new TestHarnessInitializationException("Failed to create root ACL");
             }
         }
         logger.debug("\n========== CHECK TEST SUBJECT ROOT");
@@ -182,9 +178,6 @@ public class TestSubject {
 
             // create a root container for all the test cases in this run
             testRunContainer = rootTestContainer.reserveContainer(UUID.randomUUID().toString()).instantiate();
-            if (testRunContainer == null) {
-                throw new Exception("Cannot create test run container");
-            }
             logger.debug("Test run container content: {}", testRunContainer.getContentAsTurtle());
             logger.debug("Test run container access controls: {}", testRunContainer.getAccessDataset());
         } catch (Exception e) {

--- a/src/main/java/org/solid/testharness/http/SolidClientProvider.java
+++ b/src/main/java/org/solid/testharness/http/SolidClientProvider.java
@@ -91,17 +91,21 @@ public class SolidClientProvider {
     public HttpHeaders createResource(final URI url, final String data, final String type) throws Exception {
         final HttpResponse<Void> response = client.put(url, data, type);
         if (!HttpUtils.isSuccessful(response.statusCode())) {
-            throw new Exception("Failed to create resource - status=" + response.statusCode());
+            throw new Exception("Failed to create " + url.toString() + ", response=" + response.statusCode());
         }
         return response.headers();
     }
 
-    public HttpResponse<String> createContainer(final URI url) throws Exception {
+    public HttpHeaders createContainer(final URI url) throws Exception {
         final HttpRequest.Builder builder = HttpUtils.newRequestBuilder(url)
                 .header(HttpConstants.HEADER_CONTENT_TYPE, HttpConstants.MEDIA_TYPE_TEXT_TURTLE)
                 .header(HttpConstants.HEADER_LINK, HttpConstants.CONTAINER_LINK)
                 .PUT(HttpRequest.BodyPublishers.noBody());
-        return client.sendAuthorized(builder, HttpResponse.BodyHandlers.ofString());
+        final HttpResponse<String> response = client.sendAuthorized(builder, HttpResponse.BodyHandlers.ofString());
+        if (!HttpUtils.isSuccessful(response.statusCode())) {
+            throw new Exception("Failed to create " + url.toString() + ", response=" + response.statusCode());
+        }
+        return response.headers();
     }
 
     public URI getAclUri(final URI uri) throws IOException, InterruptedException {
@@ -123,10 +127,9 @@ public class SolidClientProvider {
         return acpLink != null ? Config.AccessControlMode.ACP : Config.AccessControlMode.WAC;
     }
 
-    public boolean createAcl(final URI url, final AccessDataset accessDataset)
-            throws IOException, InterruptedException {
+    public void createAcl(final URI url, final AccessDataset accessDataset) throws Exception {
         logger.debug("ACL: {} for {}", accessDataset.toString(), url);
-        return accessDataset.apply(client, url);
+        accessDataset.apply(client, url);
     }
 
     public AccessDataset getAcl(final URI url) throws IOException, InterruptedException {

--- a/src/main/java/org/solid/testharness/utils/SolidContainerProvider.java
+++ b/src/main/java/org/solid/testharness/utils/SolidContainerProvider.java
@@ -23,19 +23,13 @@
  */
 package org.solid.testharness.utils;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.solid.testharness.http.HttpUtils;
 import org.solid.testharness.http.SolidClientProvider;
 
 import java.net.URI;
-import java.net.http.HttpResponse;
 
 public class SolidContainerProvider extends SolidResourceProvider {
-    private static final Logger logger = LoggerFactory.getLogger(SolidContainerProvider.class);
-
-    public SolidContainerProvider(final SolidClientProvider solidClientProvider, final URI url)
-            throws IllegalArgumentException {
+    public SolidContainerProvider(final SolidClientProvider solidClientProvider, final URI url) {
         super(solidClientProvider, validateUrl(url), null, null);
     }
 
@@ -46,20 +40,9 @@ public class SolidContainerProvider extends SolidResourceProvider {
         return url;
     }
 
-    public SolidContainerProvider instantiate() {
-        try {
-            final HttpResponse<String> response = solidClientProvider.createContainer(this.url);
-            if (HttpUtils.isSuccessful(response.statusCode())) {
-                return this;
-            } else {
-                logger.error("Failed to create " + url.toString() + ", response = " + response.statusCode());
-                logger.error("Response: " + response.body());
-                return null;
-            }
-        } catch (Exception e) {
-            logger.error("createContainer: " + url.toString() + " failed", e);
-            return null;
-        }
+    public SolidContainerProvider instantiate() throws Exception {
+        solidClientProvider.createContainer(this.url);
+        return this;
     }
 
     public SolidContainerProvider reserveContainer(final String name) {
@@ -71,14 +54,8 @@ public class SolidContainerProvider extends SolidResourceProvider {
     }
 
     public SolidResourceProvider createResource(final String name, final String body, final String type) {
-        try {
-            final URI childUrl = url.resolve(HttpUtils.ensureNoSlashEnd(name));
-            logger.info("Create child in {}: {}", url, childUrl);
-            return new SolidResourceProvider(super.solidClientProvider, childUrl, body, type);
-        } catch (Exception e) {
-            logger.error("createResource in " + url.toString() + " failed", e);
-        }
-        return null;
+        final URI childUrl = url.resolve(HttpUtils.ensureNoSlashEnd(name));
+        return new SolidResourceProvider(super.solidClientProvider, childUrl, body, type);
     }
 
     public void deleteContents() throws Exception {

--- a/src/main/java/org/solid/testharness/utils/SolidResourceProvider.java
+++ b/src/main/java/org/solid/testharness/utils/SolidResourceProvider.java
@@ -83,10 +83,6 @@ public class SolidResourceProvider {
         logger.debug("SolidResourceProvider proxy for: {}", url);
     }
 
-    public boolean exists() {
-        return url != null;
-    }
-
     public URI getUrl() {
         return url;
     }
@@ -135,11 +131,10 @@ public class SolidResourceProvider {
         return getAclUrl() != null ? solidClientProvider.getAcl(aclUrl) : null;
     }
 
-    public boolean setAccessDataset(final AccessDataset accessDataset) throws Exception {
-        if (Boolean.FALSE.equals(aclLinkAvailable)) return false;
+    public void setAccessDataset(final AccessDataset accessDataset) throws Exception {
         final URI aclUrl = getAclUrl();
-        if (aclUrl == null) return false;
-        return solidClientProvider.createAcl(aclUrl, accessDataset);
+        if (aclUrl == null) throw new Exception("Failed to find ACL Link for this resource");
+        solidClientProvider.createAcl(aclUrl, accessDataset);
     }
 
     public SolidContainerProvider findStorage() throws Exception {

--- a/src/test/java/org/solid/testharness/accesscontrol/AbstractAccessDatasetBuilderTest.java
+++ b/src/test/java/org/solid/testharness/accesscontrol/AbstractAccessDatasetBuilderTest.java
@@ -194,9 +194,7 @@ class AbstractAccessDatasetBuilderTest {
         }
 
         @Override
-        public boolean apply(final Client client, final URI uri) {
-            return false;
-        }
+        public void apply(final Client client, final URI uri) { }
     }
 
     class TestAccessDatasetBuilder extends AbstractAccessDatasetBuilder {

--- a/src/test/java/org/solid/testharness/accesscontrol/AccessDatasetAcpLegacyTest.java
+++ b/src/test/java/org/solid/testharness/accesscontrol/AccessDatasetAcpLegacyTest.java
@@ -134,7 +134,7 @@ class AccessDatasetAcpLegacyLegacyTest {
         final AccessDataset accessDataset = new AccessDatasetAcpLegacy(
                 TestUtils.loadStringFromFile("src/test/resources/utils/vcard.ttl"), ACL_URI
         );
-        assertTrue(accessDataset.apply(mockClient, RESOURCE_URI));
+        assertDoesNotThrow(() -> accessDataset.apply(mockClient, RESOURCE_URI));
     }
 
     @Test
@@ -145,14 +145,14 @@ class AccessDatasetAcpLegacyLegacyTest {
         final AccessDataset accessDataset = new AccessDatasetAcpLegacy(
                 TestUtils.loadStringFromFile("src/test/resources/utils/vcard.ttl"), ACL_URI
         );
-        assertFalse(accessDataset.apply(mockClient, RESOURCE_URI));
+        assertThrows(Exception.class, () -> accessDataset.apply(mockClient, RESOURCE_URI));
     }
 
     @Test
-    void applyNull() throws IOException, InterruptedException {
+    void applyNull() {
         final Client mockClient = mock(Client.class);
         final AccessDataset accessDataset = new AccessDatasetAcpLegacy(Collections.emptyList(), ACL_URI.toString());
-        assertTrue(accessDataset.apply(mockClient, RESOURCE_URI));
+        assertDoesNotThrow(() -> accessDataset.apply(mockClient, RESOURCE_URI));
     }
 
     @Test

--- a/src/test/java/org/solid/testharness/accesscontrol/AccessDatasetAcpTest.java
+++ b/src/test/java/org/solid/testharness/accesscontrol/AccessDatasetAcpTest.java
@@ -135,7 +135,7 @@ class AccessDatasetAcpTest {
         final AccessDataset accessDataset = new AccessDatasetAcp(
                 TestUtils.loadStringFromFile("src/test/resources/utils/vcard.ttl"), ACL_URI
         );
-        assertTrue(accessDataset.apply(mockClient, RESOURCE_URI));
+        assertDoesNotThrow(() -> accessDataset.apply(mockClient, RESOURCE_URI));
     }
 
     @Test
@@ -146,14 +146,14 @@ class AccessDatasetAcpTest {
         final AccessDataset accessDataset = new AccessDatasetAcp(
                 TestUtils.loadStringFromFile("src/test/resources/utils/vcard.ttl"), ACL_URI
         );
-        assertFalse(accessDataset.apply(mockClient, RESOURCE_URI));
+        assertThrows(Exception.class, () -> accessDataset.apply(mockClient, RESOURCE_URI));
     }
 
     @Test
-    void applyNull() throws IOException, InterruptedException {
+    void applyNull() {
         final Client mockClient = mock(Client.class);
         final AccessDataset accessDataset = new AccessDatasetAcp(Collections.emptyList(), ACL_URI.toString());
-        assertTrue(accessDataset.apply(mockClient, RESOURCE_URI));
+        assertDoesNotThrow(() -> accessDataset.apply(mockClient, RESOURCE_URI));
     }
 
     @Test

--- a/src/test/java/org/solid/testharness/accesscontrol/AccessDatasetTest.java
+++ b/src/test/java/org/solid/testharness/accesscontrol/AccessDatasetTest.java
@@ -159,8 +159,6 @@ class AccessDatasetTest {
         }
 
         @Override
-        public boolean apply(final Client client, final URI uri) {
-            return false;
-        }
+        public void apply(final Client client, final URI uri) { }
     }
 }

--- a/src/test/java/org/solid/testharness/accesscontrol/AccessDatasetWacTest.java
+++ b/src/test/java/org/solid/testharness/accesscontrol/AccessDatasetWacTest.java
@@ -110,7 +110,7 @@ class AccessDatasetWacTest {
         final AccessDataset accessDataset = new AccessDatasetWac(
                 TestUtils.loadStringFromFile("src/test/resources/utils/vcard.ttl"), ACL_URI
         );
-        assertTrue(accessDataset.apply(mockClient, RESOURCE_URI));
+        assertDoesNotThrow(() -> accessDataset.apply(mockClient, RESOURCE_URI));
     }
 
     @Test
@@ -121,14 +121,14 @@ class AccessDatasetWacTest {
         final AccessDataset accessDataset = new AccessDatasetWac(
                 TestUtils.loadStringFromFile("src/test/resources/utils/vcard.ttl"), ACL_URI
         );
-        assertFalse(accessDataset.apply(mockClient, RESOURCE_URI));
+        assertThrows(Exception.class, () -> accessDataset.apply(mockClient, RESOURCE_URI));
     }
 
     @Test
-    void applyNull() throws IOException, InterruptedException {
+    void applyNull() {
         final Client mockClient = mock(Client.class);
         final AccessDataset accessDataset = new AccessDatasetWac(Collections.emptyList(), ACL_URI.toString());
-        assertTrue(accessDataset.apply(mockClient, RESOURCE_URI));
+        assertDoesNotThrow(() -> accessDataset.apply(mockClient, RESOURCE_URI));
     }
 
     @Test

--- a/src/test/java/org/solid/testharness/api/RDFUtilsTest.java
+++ b/src/test/java/org/solid/testharness/api/RDFUtilsTest.java
@@ -44,7 +44,7 @@ class RDFUtilsTest {
     private static final String MEMBERS = String.format("<%s> <%s> <%s>.", TEST_URL, LDP.CONTAINS, CHLID);
 
     @Test
-    void turtleToTripleArray() throws Exception {
+    void turtleToTripleArray() {
         final List<String> triples = RDFUtils.turtleToTripleArray(TestData.SAMPLE_TURTLE, TestData.SAMPLE_BASE);
         assertNotNull(triples);
         assertEquals(1, triples.size());
@@ -57,7 +57,7 @@ class RDFUtilsTest {
     }
 
     @Test
-    void jsonLdToTripleArray() throws Exception {
+    void jsonLdToTripleArray() {
         final List<String> triples = RDFUtils.jsonLdToTripleArray(TestData.SAMPLE_JSONLD, TestData.SAMPLE_BASE);
         assertNotNull(triples);
         assertEquals(1, triples.size());
@@ -70,7 +70,7 @@ class RDFUtilsTest {
     }
 
     @Test
-    void rdfaToTripleArray() throws Exception {
+    void rdfaToTripleArray() {
         final List<String> triples = RDFUtils.rdfaToTripleArray(TestData.SAMPLE_HTML, TestData.SAMPLE_BASE);
         logger.error(Arrays.toString(triples.toArray()));
         assertNotNull(triples);
@@ -84,14 +84,14 @@ class RDFUtilsTest {
     }
 
     @Test
-    void parseMembers() throws Exception {
+    void parseMembers() {
         final List<String> members = RDFUtils.parseContainerContents(MEMBERS, TEST_URL);
         assertFalse(members.isEmpty());
         assertEquals(CHLID, members.get(0));
     }
 
     @Test
-    void parseMembersEmpty() throws Exception {
+    void parseMembersEmpty() {
         final List<String> members = RDFUtils.parseContainerContents(NO_MEMBERS, TEST_URL);
         assertTrue(members.isEmpty());
     }
@@ -101,6 +101,7 @@ class RDFUtilsTest {
         final Exception exception = assertThrows(Exception.class,
                 () -> RDFUtils.parseContainerContents("BAD", TEST_URL)
         );
-        assertEquals("Bad container listing", exception.getMessage());
+        assertTrue(exception.getMessage().contains("TestHarnessException: Bad container listing"));
+        assertTrue(exception.getMessage().contains("RDFParseException: Unexpected end of file"));
     }
 }

--- a/src/test/java/org/solid/testharness/api/SolidClientTest.java
+++ b/src/test/java/org/solid/testharness/api/SolidClientTest.java
@@ -29,6 +29,7 @@ import org.solid.testharness.http.SolidClientProvider;
 
 import java.util.Collections;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -45,5 +46,13 @@ public class SolidClientTest {
         final SolidClient solidClient = new SolidClient(solidClientProvider);
         final var headers = solidClient.getAuthHeaders("GET", "URL");
         assertTrue(headers.isEmpty());
+    }
+
+    @Test
+    void getAuthHeadersException() {
+        final SolidClientProvider solidClientProvider = mock(SolidClientProvider.class);
+        when(solidClientProvider.getClient()).thenThrow(new NullPointerException("FAIL"));
+        final SolidClient solidClient = new SolidClient(solidClientProvider);
+        assertThrows(TestHarnessException.class, () -> solidClient.getAuthHeaders("GET", "URL"));
     }
 }

--- a/src/test/java/org/solid/testharness/api/SolidContainerTest.java
+++ b/src/test/java/org/solid/testharness/api/SolidContainerTest.java
@@ -46,11 +46,18 @@ class SolidContainerTest {
         final SolidClientProvider solidClientProvider = mock(SolidClientProvider.class);
         final SolidClient solidClient = new SolidClient(solidClientProvider);
         final SolidContainer solidContainer = SolidContainer.create(solidClient, TEST_URL.toString());
-        assertTrue(solidContainer.exists());
+        assertEquals(TEST_URL.toString(), solidContainer.getUrl());
     }
 
     @Test
-    void instantiate() {
+    void testCreateException() {
+        final SolidClientProvider solidClientProvider = mock(SolidClientProvider.class);
+        final SolidClient solidClient = new SolidClient(solidClientProvider);
+        assertThrows(TestHarnessException.class, () -> SolidContainer.create(solidClient, "NOT_CONTAINER"));
+    }
+
+    @Test
+    void instantiate() throws Exception {
         final SolidContainerProvider solidContainerProvider = mock(SolidContainerProvider.class);
         final SolidContainer solidContainer = new SolidContainer(solidContainerProvider);
         assertEquals(solidContainer, solidContainer.instantiate());
@@ -58,7 +65,15 @@ class SolidContainerTest {
     }
 
     @Test
-    void reserveContainer() {
+    void instantiateException() throws Exception {
+        final SolidContainerProvider solidContainerProvider = mock(SolidContainerProvider.class);
+        doThrow(new Exception("FAIL")).when(solidContainerProvider).instantiate();
+        final SolidContainer solidContainer = new SolidContainer(solidContainerProvider);
+        assertThrows(TestHarnessException.class, solidContainer::instantiate);
+    }
+
+    @Test
+    void reserveContainer() throws Exception {
         final SolidContainerProvider solidContainerProvider = mock(SolidContainerProvider.class);
         final SolidContainerProvider newContainer = mock(SolidContainerProvider.class);
         when(solidContainerProvider.reserveContainer(any())).thenReturn(newContainer);
@@ -69,7 +84,15 @@ class SolidContainerTest {
     }
 
     @Test
-    void createContainer() {
+    void reserveContainerException() {
+        final SolidContainerProvider solidContainerProvider = mock(SolidContainerProvider.class);
+        when(solidContainerProvider.reserveContainer(any())).thenThrow(new RuntimeException("FAIL"));
+        final SolidContainer solidContainer = new SolidContainer(solidContainerProvider);
+        assertThrows(TestHarnessException.class, solidContainer::reserveContainer);
+    }
+
+    @Test
+    void createContainer() throws Exception {
         final SolidContainerProvider solidContainerProvider = mock(SolidContainerProvider.class);
         final SolidContainerProvider newContainer = mock(SolidContainerProvider.class);
         when(solidContainerProvider.reserveContainer(any())).thenReturn(newContainer);
@@ -77,6 +100,14 @@ class SolidContainerTest {
         assertNotNull(solidContainer.createContainer());
         verify(solidContainerProvider).reserveContainer(any());
         verify(newContainer).instantiate();
+    }
+
+    @Test
+    void createContainerException() {
+        final SolidContainerProvider solidContainerProvider = mock(SolidContainerProvider.class);
+        when(solidContainerProvider.reserveContainer(any())).thenThrow(new RuntimeException("FAIL"));
+        final SolidContainer solidContainer = new SolidContainer(solidContainerProvider);
+        assertThrows(TestHarnessException.class, solidContainer::createContainer);
     }
 
     @Test
@@ -90,13 +121,29 @@ class SolidContainerTest {
     }
 
     @Test
+    void reserveResourceException() {
+        final SolidContainerProvider solidContainerProvider = mock(SolidContainerProvider.class);
+        when(solidContainerProvider.reserveResource(any())).thenThrow(new RuntimeException("FAIL"));
+        final SolidContainer solidContainer = new SolidContainer(solidContainerProvider);
+        assertThrows(TestHarnessException.class, () -> solidContainer.reserveResource(".txt"));
+    }
+
+    @Test
     void createResource() {
         final SolidContainerProvider solidContainerProvider = mock(SolidContainerProvider.class);
         final SolidResourceProvider newResource = mock(SolidResourceProvider.class);
         when(solidContainerProvider.createResource(any(), any(), any())).thenReturn(newResource);
         final SolidContainer solidContainer = new SolidContainer(solidContainerProvider);
         assertNotNull(solidContainer.createResource(".txt", "hello", HttpConstants.MEDIA_TYPE_TEXT_PLAIN));
-        verify(solidContainerProvider).createResource(any(), any(), any());
+    }
+
+    @Test
+    void createResourceException() {
+        final SolidContainerProvider solidContainerProvider = mock(SolidContainerProvider.class);
+        when(solidContainerProvider.createResource(any(), any(), any())).thenThrow(new RuntimeException("FAIL"));
+        final SolidContainer solidContainer = new SolidContainer(solidContainerProvider);
+        assertThrows(TestHarnessException.class,
+                () -> solidContainer.createResource(".txt", "hello", HttpConstants.MEDIA_TYPE_TEXT_PLAIN));
     }
 
     @Test
@@ -111,7 +158,15 @@ class SolidContainerTest {
     }
 
     @Test
-    void parseMembers() throws Exception {
+    void listMembersException() throws Exception {
+        final SolidContainerProvider solidContainerProvider = mock(SolidContainerProvider.class);
+        when(solidContainerProvider.getContentAsTurtle()).thenThrow(new Exception("FAIL"));
+        final SolidContainer solidContainer = new SolidContainer(solidContainerProvider);
+        assertThrows(TestHarnessException.class, solidContainer::listMembers);
+    }
+
+    @Test
+    void parseMembers() {
         final SolidContainerProvider solidContainerProvider = mock(SolidContainerProvider.class);
         when(solidContainerProvider.getUrl()).thenReturn(TEST_URL);
         final SolidContainer solidContainer = new SolidContainer(solidContainerProvider);
@@ -121,10 +176,26 @@ class SolidContainerTest {
     }
 
     @Test
+    void parseMembersException() {
+        final SolidContainerProvider solidContainerProvider = mock(SolidContainerProvider.class);
+        when(solidContainerProvider.getUrl()).thenThrow(new RuntimeException("FAIL"));
+        final SolidContainer solidContainer = new SolidContainer(solidContainerProvider);
+        assertThrows(TestHarnessException.class, () -> solidContainer.parseMembers(MEMBERS));
+    }
+
+    @Test
     void deleteContents() throws Exception {
         final SolidContainerProvider solidContainerProvider = mock(SolidContainerProvider.class);
         final SolidContainer solidContainer = new SolidContainer(solidContainerProvider);
         assertDoesNotThrow(solidContainer::deleteContents);
         verify(solidContainerProvider).deleteContents();
+    }
+
+    @Test
+    void deleteContentsException() throws Exception {
+        final SolidContainerProvider solidContainerProvider = mock(SolidContainerProvider.class);
+        doThrow(new Exception("FAIL")).when(solidContainerProvider).deleteContents();
+        final SolidContainer solidContainer = new SolidContainer(solidContainerProvider);
+        assertThrows(TestHarnessException.class, solidContainer::deleteContents);
     }
 }

--- a/src/test/java/org/solid/testharness/api/SolidResourceTest.java
+++ b/src/test/java/org/solid/testharness/api/SolidResourceTest.java
@@ -35,7 +35,6 @@ import org.solid.testharness.utils.SolidResourceProvider;
 import java.net.URI;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 @QuarkusTest
@@ -49,6 +48,14 @@ class SolidResourceTest {
         final SolidResource solidResource = SolidResource.create(solidClient, TEST_URL.toString(), "hello",
                 HttpConstants.MEDIA_TYPE_TEXT_PLAIN);
         assertTrue(solidResource.exists());
+    }
+
+    @Test
+    void testCreateException() {
+        final SolidClientProvider solidClientProvider = mock(SolidClientProvider.class);
+        final SolidClient solidClient = new SolidClient(solidClientProvider);
+        assertThrows(TestHarnessException.class,
+                () ->  SolidResource.create(solidClient, null, null, null));
     }
 
     @Test
@@ -118,6 +125,14 @@ class SolidResourceTest {
     }
 
     @Test
+    void getAclUrlException() throws Exception {
+        final SolidResourceProvider solidResourceProvider = mock(SolidResourceProvider.class);
+        when(solidResourceProvider.getAclUrl()).thenThrow(new Exception("FAIL"));
+        final SolidResource solidResource = new SolidResource(solidResourceProvider);
+        assertThrows(TestHarnessException.class, solidResource::getAclUrl);
+    }
+
+    @Test
     void findStorage() throws Exception {
         final SolidResourceProvider solidResourceProvider = mock(SolidResourceProvider.class);
         final SolidContainerProvider solidContainerProvider = mock(SolidContainerProvider.class);
@@ -136,6 +151,14 @@ class SolidResourceTest {
     }
 
     @Test
+    void findStorageException() throws Exception {
+        final SolidResourceProvider solidResourceProvider = mock(SolidResourceProvider.class);
+        when(solidResourceProvider.findStorage()).thenThrow(new Exception("FAIL"));
+        final SolidResource solidResource = new SolidResource(solidResourceProvider);
+        assertThrows(TestHarnessException.class, solidResource::findStorage);
+    }
+
+    @Test
     void isStorageType() throws Exception {
         final SolidResourceProvider solidResourceProvider = mock(SolidResourceProvider.class);
         when(solidResourceProvider.isStorageType()).thenReturn(true);
@@ -144,7 +167,15 @@ class SolidResourceTest {
     }
 
     @Test
-    void getAccessDatasetBuilderNoParams() throws Exception {
+    void isStorageTypeException() throws Exception {
+        final SolidResourceProvider solidResourceProvider = mock(SolidResourceProvider.class);
+        when(solidResourceProvider.isStorageType()).thenThrow(new Exception("FAIL"));
+        final SolidResource resource = new SolidResource(solidResourceProvider);
+        assertThrows(TestHarnessException.class, resource::isStorageType);
+    }
+
+    @Test
+    void getAccessDatasetBuilderWithParam() throws Exception {
         final SolidResourceProvider solidResourceProvider = mock(SolidResourceProvider.class);
         final AccessDatasetBuilder accessDatasetBuilder = mock(AccessDatasetBuilder.class);
         when(solidResourceProvider.getAccessDatasetBuilder()).thenReturn(accessDatasetBuilder);
@@ -162,6 +193,14 @@ class SolidResourceTest {
     }
 
     @Test
+    void getAccessDatasetBuilderException() throws Exception {
+        final SolidResourceProvider solidResourceProvider = mock(SolidResourceProvider.class);
+        when(solidResourceProvider.getAccessDatasetBuilder()).thenThrow(new Exception("FAIL"));
+        final SolidResource resource = new SolidResource(solidResourceProvider);
+        assertThrows(TestHarnessException.class, resource::getAccessDatasetBuilder);
+    }
+
+    @Test
     void getAccessDataset() throws Exception {
         final SolidResourceProvider solidResourceProvider = mock(SolidResourceProvider.class);
         final AccessDataset accessDataset = mock(AccessDataset.class);
@@ -171,11 +210,28 @@ class SolidResourceTest {
     }
 
     @Test
-    void setAccessDatasetNoUrl() throws Exception {
+    void getAccessDatasetException() throws Exception {
         final SolidResourceProvider solidResourceProvider = mock(SolidResourceProvider.class);
-        when(solidResourceProvider.setAccessDataset(any())).thenReturn(true);
+        final AccessDataset accessDataset = mock(AccessDataset.class);
+        when(solidResourceProvider.getAccessDataset()).thenThrow(new Exception("FAIL"));
         final SolidResource resource = new SolidResource(solidResourceProvider);
-        assertTrue(resource.setAccessDataset(null));
+        assertThrows(TestHarnessException.class, resource::getAccessDataset);
+    }
+
+    @Test
+    void setAccessDataset() throws Exception {
+        final SolidResourceProvider solidResourceProvider = mock(SolidResourceProvider.class);
+        final SolidResource resource = new SolidResource(solidResourceProvider);
+        assertDoesNotThrow(() -> resource.setAccessDataset(null));
+        verify(solidResourceProvider).setAccessDataset(null);
+    }
+
+    @Test
+    void setAccessDatasetException() throws Exception {
+        final SolidResourceProvider solidResourceProvider = mock(SolidResourceProvider.class);
+        doThrow(new Exception("FAIL")).when(solidResourceProvider).setAccessDataset(any());
+        final SolidResource resource = new SolidResource(solidResourceProvider);
+        assertThrows(TestHarnessException.class, () -> resource.setAccessDataset(null));
     }
 
     @Test
@@ -184,6 +240,14 @@ class SolidResourceTest {
         final SolidResource resource = new SolidResource(solidResourceProvider);
         assertDoesNotThrow(resource::delete);
         verify(solidResourceProvider).delete();
+    }
+
+    @Test
+    void deleteException() throws Exception {
+        final SolidResourceProvider solidResourceProvider = mock(SolidResourceProvider.class);
+        doThrow(new Exception("FAIL")).when(solidResourceProvider).delete();
+        final SolidResource resource = new SolidResource(solidResourceProvider);
+        assertThrows(TestHarnessException.class, resource::delete);
     }
 
     @Test

--- a/src/test/java/org/solid/testharness/api/TestHarnessExceptionTest.java
+++ b/src/test/java/org/solid/testharness/api/TestHarnessExceptionTest.java
@@ -21,44 +21,30 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.solid.testharness.utils;
+package org.solid.testharness.api;
 
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-class TestHarnessInitializationExceptionTest {
-    @Test
-    void simpleConstructor() {
-        final TestHarnessInitializationException exception = new TestHarnessInitializationException("message",
-                new Exception("FAIL"));
-        assertEquals("message", exception.getMessage());
-    }
-
+class TestHarnessExceptionTest {
     @Test
     void simpleMessage() {
-        final TestHarnessInitializationException exception = new TestHarnessInitializationException("message");
-        assertEquals("message", exception.getMessage());
+        final TestHarnessException exception = new TestHarnessException("message", new Exception("FAIL"));
+        assertEquals("org.solid.testharness.api.TestHarnessException: message\n" +
+                "Caused by: java.lang.Exception: FAIL", exception.getMessage());
     }
 
     @Test
-    void simpleMessageNullArgs() {
-        final TestHarnessInitializationException exception = new TestHarnessInitializationException("message",
-                (String) null);
-        assertEquals("message", exception.getMessage());
+    void noMessage() {
+        final TestHarnessException exception = new TestHarnessException(null, new Exception("FAIL"));
+        assertEquals("org.solid.testharness.api.TestHarnessException: \n" +
+                "Caused by: java.lang.Exception: FAIL", exception.getMessage());
     }
 
     @Test
-    void simpleMessageArgs1() {
-        final TestHarnessInitializationException exception = new TestHarnessInitializationException("message %s",
-                "arg1");
-        assertEquals("message arg1", exception.getMessage());
-    }
-
-    @Test
-    void simpleMessageArgs2() {
-        final TestHarnessInitializationException exception = new TestHarnessInitializationException("message %s %s",
-                "arg1", "arg2");
-        assertEquals("message arg1 arg2", exception.getMessage());
+    void noCause() {
+        final TestHarnessException exception = new TestHarnessException("message", null);
+        assertEquals("org.solid.testharness.api.TestHarnessException: message", exception.getMessage());
     }
 }

--- a/src/test/java/org/solid/testharness/api/UtilsTest.java
+++ b/src/test/java/org/solid/testharness/api/UtilsTest.java
@@ -122,13 +122,18 @@ public class UtilsTest {
 
     @Test
     void parseWacAllowHeaderNull() {
-        assertThrows(NullPointerException.class, () -> Utils.parseWacAllowHeader(null));
+        assertThrows(TestHarnessException.class, () -> Utils.parseWacAllowHeader(null));
     }
 
     @Test
     void resolveUriNulls() {
         assertNull(Utils.resolveUri(null, ""));
         assertNull(Utils.resolveUri("", null));
+    }
+
+    @Test
+    void resolveUriException() {
+        assertThrows(TestHarnessException.class, () -> Utils.resolveUri("~://?", ""));
     }
 
     @Test

--- a/src/test/java/org/solid/testharness/config/TestSubjectTest.java
+++ b/src/test/java/org/solid/testharness/config/TestSubjectTest.java
@@ -182,7 +182,7 @@ public class TestSubjectTest {
 
         final Exception exception = assertThrows(TestHarnessInitializationException.class,
                 () -> testSubject.prepareServer());
-        assertEquals("Failed to prepare server: java.lang.Exception: Cannot create test run container",
+        assertEquals("Failed to prepare server: java.io.IOException",
                 exception.getMessage());
     }
 
@@ -251,7 +251,8 @@ public class TestSubjectTest {
 
         final Exception exception = assertThrows(TestHarnessInitializationException.class,
                 () -> testSubject.prepareServer());
-        assertEquals("Failed to create root ACL", exception.getMessage());
+        assertEquals("Failed to create root ACL: java.lang.Exception: Error response=500 trying to apply ACL",
+                exception.getMessage());
     }
 
     @Test

--- a/src/test/java/org/solid/testharness/utils/DataRepositoryTest.java
+++ b/src/test/java/org/solid/testharness/utils/DataRepositoryTest.java
@@ -117,7 +117,10 @@ class DataRepositoryTest {
         final StepResult str1 = mock(StepResult.class);
         when(str1.getStep()).thenReturn(step1);
         when(str1.getResult()).thenReturn(res1);
-        when(str1.getStepLog()).thenReturn("STEP1 LOG");
+        when(str1.getStepLog()).thenReturn("STEP1 LOG\n" +
+                "js failed:\n>>>>?<<<<\n" +
+                "org.graalvm.polyglot.PolyglotException: EXCEPTION\n" +
+                "Caused by EXCEPTION2\nSTACK1\nSTACK2\n- <js>LAST\nother stuff");
         final StepResult str2 = mock(StepResult.class);
         when(str2.getStep()).thenReturn(step2);
         when(str2.getResult()).thenReturn(res2);
@@ -129,6 +132,8 @@ class DataRepositoryTest {
         assertTrue(result.contains("dcterms:title \"FEATURE NAME\""));
         assertTrue(result.contains("earl:outcome earl:failed"));
         assertTrue(result.contains("prov:value earl:passed"));
+        assertTrue(result.contains("dcterms:description \"\"\"STEP1 LOG\n" +
+                "EXCEPTION\nCaused by EXCEPTION2\nSTACK1\n- <js>LAST"));
     }
 
     @Test

--- a/src/test/java/org/solid/testharness/utils/SolidResourceProviderTest.java
+++ b/src/test/java/org/solid/testharness/utils/SolidResourceProviderTest.java
@@ -83,7 +83,7 @@ class SolidResourceProviderTest {
     @Test
     void testConstructorNoBody() {
         final SolidResourceProvider resource = new SolidResourceProvider(solidClientProvider, TEST_URL);
-        assertTrue(resource.exists());
+        assertEquals(TEST_URL, resource.getUrl());
     }
 
     @Test
@@ -99,7 +99,7 @@ class SolidResourceProviderTest {
         final SolidResourceProvider resource = new SolidResourceProvider(solidClientProvider, TEST_URL, "hello",
                 HttpConstants.MEDIA_TYPE_TEXT_PLAIN);
 
-        assertTrue(resource.exists());
+        assertEquals(TEST_URL, resource.getUrl());
         assertEquals(TEST_ACL_URL, resource.getAclUrl());
     }
 
@@ -115,7 +115,7 @@ class SolidResourceProviderTest {
         final SolidResourceProvider resource = new SolidResourceProvider(solidClientProvider, TEST_URL, "hello",
                 HttpConstants.MEDIA_TYPE_TEXT_PLAIN);
 
-        assertTrue(resource.exists());
+        assertEquals(TEST_URL, resource.getUrl());
         assertNull(resource.getAclUrl());
     }
 
@@ -129,7 +129,7 @@ class SolidResourceProviderTest {
         final SolidResourceProvider resource = new SolidResourceProvider(solidClientProvider, TEST_URL, "hello",
                 HttpConstants.MEDIA_TYPE_TEXT_PLAIN);
 
-        assertTrue(resource.exists());
+        assertEquals(TEST_URL, resource.getUrl());
         assertNull(resource.getAclUrl());
     }
 
@@ -143,7 +143,7 @@ class SolidResourceProviderTest {
         final SolidResourceProvider resource = new SolidResourceProvider(solidClientProvider, TEST_URL, "hello",
                 HttpConstants.MEDIA_TYPE_TEXT_PLAIN);
 
-        assertTrue(resource.exists());
+        assertEquals(TEST_URL, resource.getUrl());
         assertEquals(lookedUpAclUrl, resource.getAclUrl());
     }
 
@@ -155,7 +155,7 @@ class SolidResourceProviderTest {
         final SolidResourceProvider resource = new SolidResourceProvider(solidClientProvider, TEST_URL, "hello",
                 HttpConstants.MEDIA_TYPE_TEXT_PLAIN);
 
-        assertFalse(resource.exists());
+        assertNull(resource.getUrl());
     }
 
     @Test
@@ -167,9 +167,8 @@ class SolidResourceProviderTest {
                 HttpConstants.MEDIA_TYPE_TEXT_PLAIN);
         final SolidContainerProvider container = resource.getContainer();
 
-        assertTrue(resource.exists());
+        assertEquals(TEST_URL, resource.getUrl());
         assertFalse(resource.isContainer());
-        assertTrue(container.exists());
         assertEquals(ROOT_URL, container.getUrl());
     }
 
@@ -183,10 +182,8 @@ class SolidResourceProviderTest {
         final SolidContainerProvider container = resource.getContainer();
         final SolidContainerProvider nextContainer = container.getContainer();
 
-        assertTrue(resource.exists());
-        assertTrue(container.exists());
+        assertEquals(ROOT_URL.resolve("/container/resource"), resource.getUrl());
         assertEquals(ROOT_URL.resolve("/container/"), container.getUrl());
-        assertTrue(nextContainer.exists());
         assertEquals(ROOT_URL, nextContainer.getUrl());
     }
 
@@ -200,8 +197,7 @@ class SolidResourceProviderTest {
         final SolidContainerProvider container = resource.getContainer();
         final SolidContainerProvider nextContainer = container.getContainer();
 
-        assertTrue(resource.exists());
-        assertTrue(container.exists());
+        assertEquals(TEST_URL, resource.getUrl());
         assertEquals(ROOT_URL, container.getUrl());
         assertNull(nextContainer);
     }
@@ -213,7 +209,7 @@ class SolidResourceProviderTest {
                 .thenReturn(null);
         final SolidResourceProvider resource = new SolidResourceProvider(solidClientProvider, TEST_URL, "hello",
                 HttpConstants.MEDIA_TYPE_TEXT_PLAIN);
-        assertFalse(resource.setAccessDataset(accessDataset));
+        assertThrows(Exception.class, () -> resource.setAccessDataset(accessDataset));
     }
 
     @Test
@@ -229,9 +225,7 @@ class SolidResourceProviderTest {
 
         final SolidResourceProvider resource = new SolidResourceProvider(solidClientProvider, TEST_URL, "hello",
                 HttpConstants.MEDIA_TYPE_TEXT_PLAIN);
-        assertFalse(resource.setAccessDataset(accessDataset));
-        // second attempt short cuts as false
-        assertFalse(resource.setAccessDataset(accessDataset));
+        assertThrows(Exception.class, () -> resource.setAccessDataset(accessDataset));
     }
 
     @Test
@@ -244,13 +238,12 @@ class SolidResourceProviderTest {
                 .thenReturn(headers);
         when(solidClientProvider.getAclUri(headers)).thenReturn(TEST_ACL_URL);
         when(solidClientProvider.getAclUri(TEST_URL)).thenReturn(TEST_ACL_URL);
-        when(solidClientProvider.createAcl(TEST_ACL_URL, accessDataset)).thenReturn(true);
 
         when(solidClientProvider.createResource(TEST_URL, "hello", HttpConstants.MEDIA_TYPE_TEXT_PLAIN))
                 .thenReturn(headers);
         final SolidResourceProvider resource = new SolidResourceProvider(solidClientProvider, TEST_URL, "hello",
                 HttpConstants.MEDIA_TYPE_TEXT_PLAIN);
-        assertTrue(resource.setAccessDataset(accessDataset));
+        assertDoesNotThrow(() -> resource.setAccessDataset(accessDataset));
     }
 
     @Test
@@ -268,7 +261,6 @@ class SolidResourceProviderTest {
                 .thenThrow(new Exception("Failed as expected"));
         final SolidResourceProvider resource = new SolidResourceProvider(solidClientProvider, TEST_URL, "hello",
                 HttpConstants.MEDIA_TYPE_TEXT_PLAIN);
-        assertFalse(resource.exists());
         assertNull(resource.getUrl());
     }
 


### PR DESCRIPTION
All exceptions are trapped at the API layer and wrapped as `TestHarnessException`s which display well in reports. This improves the information in the report but also allows us to simplify the tests and remove tests such as `resource.exists()`.

There are 3 commits - the main code changes, the resulting unit test changes and then changes to the example tests scripts.

Once this PR is merged we will update the specification-tests repo to bring it into line with this, then do a release of the CTH which will create an image containing the matching tests.