### PR TITLE
Improve raw http send method and http client

### DIFF
--- a/example/web-access-control/protected-operation/read-resource-access-R.feature
+++ b/example/web-access-control/protected-operation/read-resource-access-R.feature
@@ -53,9 +53,9 @@ Feature: Bob can only read an RDF resource to which he is only granted read acce
     Then status 403
 
   Scenario: Bob cannot use an unknown method on the resource
-    * def response = clients.alice.sendAuthorized('DAHU', resource.url, null, null, 'HTTP_1_1')
+    * def response = clients.bob.sendAuthorized('DAHU', resource.url, null, null, 'HTTP_1_1')
     Then assert response.status == 405
 
   Scenario: Bob cannot use an unknown method on the resource
-    * def response = clients.alice.sendAuthorized('DAHU', resource.url, null, null, 'HTTP_2')
+    * def response = clients.bob.sendAuthorized('DAHU', resource.url, null, null, 'HTTP_2')
     Then assert response.status == 405

--- a/example/web-access-control/protected-operation/read-resource-access-R.feature
+++ b/example/web-access-control/protected-operation/read-resource-access-R.feature
@@ -53,5 +53,9 @@ Feature: Bob can only read an RDF resource to which he is only granted read acce
     Then status 403
 
   Scenario: Bob cannot use an unknown method on the resource
-    * def response = clients.alice.sendAuthorized('DAHU', resource.url, null, null)
+    * def response = clients.alice.sendAuthorized('DAHU', resource.url, null, null, 'HTTP_1_1')
+    Then assert response.status == 405
+
+  Scenario: Bob cannot use an unknown method on the resource
+    * def response = clients.alice.sendAuthorized('DAHU', resource.url, null, null, 'HTTP_2')
     Then assert response.status == 405

--- a/src/main/java/org/solid/testharness/api/SolidClient.java
+++ b/src/main/java/org/solid/testharness/api/SolidClient.java
@@ -65,6 +65,7 @@ public class SolidClient {
      * @param uri the URL of the resource
      * @param data the request body (optional)
      * @param headers a map of request headers (optional)
+     * @param version the HTTP version to use for the request (optional)
      * @return a map containing the response using the keys: status, headers, body
      */
     public Map<String, Object> send(final String method, final String uri, final String data,
@@ -73,6 +74,7 @@ public class SolidClient {
             final HttpResponse<String> response = solidClientProvider.getClient().send(method, URI.create(uri),
                     data, headers, version, false);
             return Map.of(
+                    "version", response.version(),
                     "status", response.statusCode(),
                     "body", response.body(),
                     "headers", response.headers().map()
@@ -88,6 +90,7 @@ public class SolidClient {
      * @param uri the URL of the resource
      * @param data the request body (optional)
      * @param headers a map of request headers (optional)
+     * @param version the HTTP version to use for the request (optional)
      * @return a map containing the response using the keys: status, headers, body
      */
     public Map<String, Object> sendAuthorized(final String method, final String uri, final String data,
@@ -96,6 +99,7 @@ public class SolidClient {
             final HttpResponse<String> response = solidClientProvider.getClient().send(method, URI.create(uri),
                     data, headers, version, true);
             return Map.of(
+                    "version", response.version(),
                     "status", response.statusCode(),
                     "body", response.body(),
                     "headers", response.headers().map()

--- a/src/main/java/org/solid/testharness/api/SolidClient.java
+++ b/src/main/java/org/solid/testharness/api/SolidClient.java
@@ -68,10 +68,10 @@ public class SolidClient {
      * @return a map containing the response using the keys: status, headers, body
      */
     public Map<String, Object> send(final String method, final String uri, final String data,
-                                    final Map<String, Object> headers) {
+                                    final Map<String, Object> headers, final String version) {
         try {
             final HttpResponse<String> response = solidClientProvider.getClient().send(method, URI.create(uri),
-                    data, headers, false);
+                    data, headers, version, false);
             return Map.of(
                     "status", response.statusCode(),
                     "body", response.body(),
@@ -91,10 +91,10 @@ public class SolidClient {
      * @return a map containing the response using the keys: status, headers, body
      */
     public Map<String, Object> sendAuthorized(final String method, final String uri, final String data,
-                                    final Map<String, Object> headers) {
+                                    final Map<String, Object> headers, final String version) {
         try {
             final HttpResponse<String> response = solidClientProvider.getClient().send(method, URI.create(uri),
-                    data, headers, true);
+                    data, headers, version, true);
             return Map.of(
                     "status", response.statusCode(),
                     "body", response.body(),

--- a/src/main/java/org/solid/testharness/http/Client.java
+++ b/src/main/java/org/solid/testharness/http/Client.java
@@ -43,6 +43,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 
 import static java.util.Objects.requireNonNull;
 import static java.util.UUID.randomUUID;
@@ -54,6 +55,7 @@ import static org.apache.commons.text.CharacterPredicates.LETTERS;
 // Duplicate string are null check error messages for same parameter
 public class Client {
     private static final Logger logger = LoggerFactory.getLogger(Client.class);
+    private static int MAX_RETRY = 10;
 
     private HttpClient httpClient;
     private String accessToken;
@@ -61,6 +63,7 @@ public class Client {
     private boolean dpopSupported;
     private String agent;
     private String user;
+    private int maxRetries = MAX_RETRY;
 
     public static class Builder {
         private final HttpClient.Builder clientBuilder;
@@ -128,10 +131,14 @@ public class Client {
         return user;
     }
 
+    public void setMaxRetries(final int maxRetries) {
+        this.maxRetries = maxRetries;
+    }
+
     @SuppressWarnings("checkstyle:MultipleStringLiterals") // cleaner to leave error messages local
     public HttpResponse<String> send(@NotNull final String method, @NotNull final URI url, final String data,
                                      final Map<String, Object> headers, final String version, final boolean authorized)
-            throws IOException, InterruptedException {
+            throws Exception {
         requireNonNull(url, "url is required");
         requireNonNull(method, "method is required");
         final HttpRequest.Builder builder = HttpUtils.newRequestBuilder(url);
@@ -154,9 +161,36 @@ public class Client {
         }
         final HttpRequest request = authorized ? authorize(builder).build() : builder.build();
         HttpUtils.logRequestToKarate(logger, request, data);
-        final HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+        final HttpResponse.BodyHandler<String> handler = HttpResponse.BodyHandlers.ofString();
+        final CompletableFuture<HttpResponse<String>> responseFuture =
+                httpClient.sendAsync(request, handler)
+                        .handleAsync((r, t) -> tryResend(httpClient, request, handler, 1, r, t))
+                        .thenCompose(Function.identity());
+        final HttpResponse<String> response = responseFuture.get();
         HttpUtils.logResponseToKarate(logger, response);
         return response;
+    }
+
+    private boolean shouldRetry(final HttpResponse<?> r, final Throwable t, final int count) {
+        if (r != null || count >= maxRetries) return false;
+        HttpUtils.logToKarate(logger, "Retry ({}) due to {}", count, t.toString());
+        return true;
+    }
+
+    private <T> CompletableFuture<HttpResponse<T>> tryResend(final HttpClient client, final HttpRequest request,
+                                                             final HttpResponse.BodyHandler<T> handler,
+                                                             final int count, final HttpResponse<T> resp,
+                                                             final Throwable t) {
+        if (shouldRetry(resp, t, count)) {
+            return client.sendAsync(request, handler)
+                    .handleAsync((r, x) -> tryResend(client, request, handler, count + 1, r, x))
+                    .thenCompose(Function.identity());
+        } else if (t != null) {
+            return CompletableFuture.failedFuture(t);
+        } else {
+            return CompletableFuture.completedFuture(resp);
+        }
     }
 
     public <T> HttpResponse<T> send(@NotNull final HttpRequest request,

--- a/src/main/java/org/solid/testharness/http/Client.java
+++ b/src/main/java/org/solid/testharness/http/Client.java
@@ -130,7 +130,7 @@ public class Client {
 
     @SuppressWarnings("checkstyle:MultipleStringLiterals") // cleaner to leave error messages local
     public HttpResponse<String> send(@NotNull final String method, @NotNull final URI url, final String data,
-                                     final Map<String, Object> headers, final boolean authorized)
+                                     final Map<String, Object> headers, final String version, final boolean authorized)
             throws IOException, InterruptedException {
         requireNonNull(url, "url is required");
         requireNonNull(method, "method is required");
@@ -139,6 +139,9 @@ public class Client {
             builder.method(method, HttpRequest.BodyPublishers.ofString(data));
         } else {
             builder.method(method, HttpRequest.BodyPublishers.noBody());
+        }
+        if (version != null) {
+            builder.version(HttpClient.Version.valueOf(version));
         }
         if (headers != null) {
             for (Map.Entry<String, Object> entry : headers.entrySet()) {

--- a/src/main/java/org/solid/testharness/http/HttpUtils.java
+++ b/src/main/java/org/solid/testharness/http/HttpUtils.java
@@ -89,6 +89,16 @@ public final class HttpUtils {
         return "file".equals(protocol);
     }
 
+    public static void logToKarate(final Logger fallbackLogger, final String format, final Object... arguments) {
+        final com.intuit.karate.Logger logger = Optional.ofNullable(ScenarioEngine.get())
+                .map(se -> se.logger).orElse(null);
+        if (logger != null) {
+            logger.debug(format, arguments);
+        } else if (fallbackLogger.isDebugEnabled()) {
+            fallbackLogger.debug(format, arguments);
+        }
+    }
+
     public static void logRequest(final Logger logger, final HttpRequest request) {
         if (logger.isDebugEnabled()) {
             logger.debug("request:\n{}", formatRequestLog(request, null));
@@ -96,13 +106,7 @@ public final class HttpUtils {
     }
 
     public static void logRequestToKarate(final Logger fallbackLogger, final HttpRequest request, final String body) {
-        final com.intuit.karate.Logger logger = Optional.ofNullable(ScenarioEngine.get())
-                .map(se -> se.logger).orElse(null);
-        if (logger != null) {
-            logger.debug("request:\n{}", formatRequestLog(request, body));
-        } else if (fallbackLogger.isDebugEnabled()) {
-            fallbackLogger.debug("request:\n{}", formatRequestLog(request, body));
-        }
+        logToKarate(fallbackLogger, "request:\n{}", formatRequestLog(request, body));
     }
 
     private static String formatRequestLog(final HttpRequest request, final String body) {
@@ -122,18 +126,12 @@ public final class HttpUtils {
     }
 
     public static <T> void logResponseToKarate(final Logger fallbackLogger, final HttpResponse<T> response) {
-        final com.intuit.karate.Logger logger = Optional.ofNullable(ScenarioEngine.get())
-                .map(se -> se.logger).orElse(null);
-        if (logger != null) {
-            logger.debug("response:\n{}", formatResponseLog(response));
-        } else if (fallbackLogger.isDebugEnabled()) {
-            fallbackLogger.debug("response:\n{}", formatResponseLog(response));
-        }
+        logToKarate(fallbackLogger, "response:\n{}", formatResponseLog(response));
     }
 
     private static <T> String formatResponseLog(final HttpResponse<T> response) {
         final StringBuilder sb = new StringBuilder();
-        sb.append(RESPONSE_PREFIX).append(response.statusCode()).append('\n');
+        sb.append(RESPONSE_PREFIX).append(response.version()).append(' ').append(response.statusCode()).append('\n');
         logHeaders(sb, response.headers().map(), false);
         final T body = response.body();
         if (body != null) {

--- a/src/test/java/org/solid/testharness/api/SolidClientTest.java
+++ b/src/test/java/org/solid/testharness/api/SolidClientTest.java
@@ -28,7 +28,7 @@ import org.solid.testharness.http.Client;
 import org.solid.testharness.http.SolidClientProvider;
 import org.solid.testharness.utils.TestUtils;
 
-import java.io.IOException;
+import java.net.http.HttpClient;
 import java.net.http.HttpResponse;
 import java.util.Collections;
 import java.util.Map;
@@ -61,7 +61,7 @@ public class SolidClientTest {
     }
 
     @Test
-    void send() throws IOException, InterruptedException {
+    void send() throws Exception {
         final Client client = mock(Client.class);
         final HttpResponse<String> mockStringResponse = TestUtils.mockStringResponse(200, "data");
         when(client.send(any(), any(), any(), any(), any(), eq(false))).thenReturn(mockStringResponse);
@@ -71,6 +71,7 @@ public class SolidClientTest {
         final SolidClient solidClient = new SolidClient(solidClientProvider);
         final var response = solidClient.send("GET", TestUtils.SAMPLE_BASE, "", null, null);
         assertFalse(response.isEmpty());
+        assertEquals(HttpClient.Version.HTTP_1_1, response.get("version"));
         assertEquals(200, response.get("status"));
         assertTrue(response.get("headers") instanceof Map);
         assertEquals("data", response.get("body"));
@@ -86,7 +87,7 @@ public class SolidClientTest {
     }
 
     @Test
-    void sendAuthorized() throws IOException, InterruptedException {
+    void sendAuthorized() throws Exception {
         final Client client = mock(Client.class);
         final HttpResponse<String> mockStringResponse = TestUtils.mockStringResponse(200, "data");
         when(client.send(any(), any(), any(), any(), any(), eq(true))).thenReturn(mockStringResponse);
@@ -96,6 +97,7 @@ public class SolidClientTest {
         final SolidClient solidClient = new SolidClient(solidClientProvider);
         final var response = solidClient.sendAuthorized("GET", TestUtils.SAMPLE_BASE, "", null, null);
         assertFalse(response.isEmpty());
+        assertEquals(HttpClient.Version.HTTP_1_1, response.get("version"));
         assertEquals(200, response.get("status"));
         assertTrue(response.get("headers") instanceof Map);
         assertEquals("data", response.get("body"));

--- a/src/test/java/org/solid/testharness/api/SolidClientTest.java
+++ b/src/test/java/org/solid/testharness/api/SolidClientTest.java
@@ -64,12 +64,12 @@ public class SolidClientTest {
     void send() throws IOException, InterruptedException {
         final Client client = mock(Client.class);
         final HttpResponse<String> mockStringResponse = TestUtils.mockStringResponse(200, "data");
-        when(client.send(any(), any(), any(), any(), eq(false))).thenReturn(mockStringResponse);
+        when(client.send(any(), any(), any(), any(), any(), eq(false))).thenReturn(mockStringResponse);
         final SolidClientProvider solidClientProvider = mock(SolidClientProvider.class);
         when(solidClientProvider.getClient()).thenReturn(client);
 
         final SolidClient solidClient = new SolidClient(solidClientProvider);
-        final var response = solidClient.send("GET", TestUtils.SAMPLE_BASE, "", null);
+        final var response = solidClient.send("GET", TestUtils.SAMPLE_BASE, "", null, null);
         assertFalse(response.isEmpty());
         assertEquals(200, response.get("status"));
         assertTrue(response.get("headers") instanceof Map);
@@ -82,19 +82,19 @@ public class SolidClientTest {
         when(solidClientProvider.getClient()).thenThrow(new NullPointerException("FAIL"));
         final SolidClient solidClient = new SolidClient(solidClientProvider);
         assertThrows(TestHarnessException.class,
-                () -> solidClient.send("GET", TestUtils.SAMPLE_BASE, "", null));
+                () -> solidClient.send("GET", TestUtils.SAMPLE_BASE, "", null, null));
     }
 
     @Test
     void sendAuthorized() throws IOException, InterruptedException {
         final Client client = mock(Client.class);
         final HttpResponse<String> mockStringResponse = TestUtils.mockStringResponse(200, "data");
-        when(client.send(any(), any(), any(), any(), eq(true))).thenReturn(mockStringResponse);
+        when(client.send(any(), any(), any(), any(), any(), eq(true))).thenReturn(mockStringResponse);
         final SolidClientProvider solidClientProvider = mock(SolidClientProvider.class);
         when(solidClientProvider.getClient()).thenReturn(client);
 
         final SolidClient solidClient = new SolidClient(solidClientProvider);
-        final var response = solidClient.sendAuthorized("GET", TestUtils.SAMPLE_BASE, "", null);
+        final var response = solidClient.sendAuthorized("GET", TestUtils.SAMPLE_BASE, "", null, null);
         assertFalse(response.isEmpty());
         assertEquals(200, response.get("status"));
         assertTrue(response.get("headers") instanceof Map);
@@ -107,6 +107,6 @@ public class SolidClientTest {
         when(solidClientProvider.getClient()).thenThrow(new NullPointerException("FAIL"));
         final SolidClient solidClient = new SolidClient(solidClientProvider);
         assertThrows(TestHarnessException.class,
-                () -> solidClient.sendAuthorized("GET", TestUtils.SAMPLE_BASE, "", null));
+                () -> solidClient.sendAuthorized("GET", TestUtils.SAMPLE_BASE, "", null, null));
     }
 }

--- a/src/test/java/org/solid/testharness/http/ClientResource.java
+++ b/src/test/java/org/solid/testharness/http/ClientResource.java
@@ -27,6 +27,7 @@ import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.http.Fault;
+import com.github.tomakehurst.wiremock.stubbing.Scenario;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 
 import java.net.URI;
@@ -64,6 +65,18 @@ public class ClientResource implements QuarkusTestResourceLifecycleManager {
                 .withHeader("LIST", matching("ITEM1"))
                 .withHeader("LIST", matching("ITEM2"))
                 .willReturn(WireMock.aResponse().withStatus(200)));
+
+        wireMockServer.stubFor(WireMock.request("RETRY", WireMock.urlEqualTo("/retry"))
+                .inScenario("RETRY").whenScenarioStateIs(Scenario.STARTED)
+                .willReturn(WireMock.aResponse().withFault(Fault.EMPTY_RESPONSE))
+                .willSetStateTo("FAILED"));
+
+        wireMockServer.stubFor(WireMock.request("RETRY", WireMock.urlEqualTo("/retry"))
+                .inScenario("RETRY").whenScenarioStateIs("FAILED")
+                .willReturn(WireMock.aResponse().withStatus(405)));
+
+        wireMockServer.stubFor(WireMock.request("RETRY", WireMock.urlEqualTo("/retryfails"))
+                .willReturn(WireMock.aResponse().withFault(Fault.EMPTY_RESPONSE)));
 
         wireMockServer.stubFor(WireMock.get(WireMock.urlEqualTo("/get/404"))
                 .willReturn(WireMock.aResponse().withStatus(404)));

--- a/src/test/java/org/solid/testharness/http/ClientTest.java
+++ b/src/test/java/org/solid/testharness/http/ClientTest.java
@@ -107,7 +107,7 @@ class ClientTest {
     void sendRawEmpty() throws IOException, InterruptedException {
         final Client client = new Client.Builder().build();
         final HttpResponse<String> response = client.send("DAHU", baseUri.resolve("/dahu/no-auth"),
-                "TEXT", null, false);
+                "TEXT", null, null, false);
         assertEquals(200, response.statusCode());
         assertEquals("", response.body());
     }
@@ -117,7 +117,7 @@ class ClientTest {
         final Client client = new Client.Builder().withDpopSupport().build();
         client.setAccessToken("ACCESS");
         final HttpResponse<String> response = client.send("DAHU", baseUri.resolve("/dahu/auth"),
-                null, null, true);
+                null, null, null, true);
         assertEquals(200, response.statusCode());
         assertEquals("AUTHENTICATED", response.body());
         assertEquals(HttpConstants.MEDIA_TYPE_TEXT_PLAIN,
@@ -127,13 +127,13 @@ class ClientTest {
     @Test
     void sendRawNullMethod() {
         final Client client = new Client.Builder().build();
-        assertThrows(NullPointerException.class, () -> client.send(null, baseUri, null, null, false));
+        assertThrows(NullPointerException.class, () -> client.send(null, baseUri, null, null, null, false));
     }
 
     @Test
     void sendRawNullUri() {
         final Client client = new Client.Builder().build();
-        assertThrows(NullPointerException.class, () -> client.send("GET", null, null, null, false));
+        assertThrows(NullPointerException.class, () -> client.send("GET", null, null, null, null, false));
     }
 
     @Test
@@ -147,7 +147,7 @@ class ClientTest {
                 "SKIP", TEST_URL
         );
         final HttpResponse<String> response = client.send("DAHU", baseUri.resolve("/dahu/headers"),
-                null, headers, false);
+                null, headers, null, false);
         assertEquals(200, response.statusCode());
     }
 

--- a/src/test/java/org/solid/testharness/utils/TestUtils.java
+++ b/src/test/java/org/solid/testharness/utils/TestUtils.java
@@ -47,6 +47,7 @@ import java.io.*;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
+import java.net.http.HttpClient;
 import java.net.http.HttpHeaders;
 import java.net.http.HttpResponse;
 import java.nio.file.Files;
@@ -95,6 +96,7 @@ public final class TestUtils {
     public static HttpResponse<String> mockStringResponse(final int status, final String body,
                                                           final Map<String, List<String>> headers) {
         final HttpResponse<String> mockResponse = mock(HttpResponse.class);
+        when(mockResponse.version()).thenReturn(HttpClient.Version.HTTP_1_1);
         when(mockResponse.statusCode()).thenReturn(status);
         when(mockResponse.body()).thenReturn(body);
         final HttpHeaders mockHeaders = HttpHeaders.of(headers, (k, v) -> true);


### PR DESCRIPTION
This was really about fixing the http client to allow retries as a workaround to a JDK error. However whilst doing this it was necessary to test both versions of HTTP so this was added to the API.