### PR TITLE
Make teardown more resilient

### DIFF
--- a/example/protocol/solid-protocol-test-manifest.ttl
+++ b/example/protocol/solid-protocol-test-manifest.ttl
@@ -5,18 +5,20 @@
 @prefix td: <http://www.w3.org/2006/03/test-description#> .
 prefix spec: <http://www.w3.org/ns/spec#>
 
+prefix sopr: <https://solidproject.org/TR/protocol#>
+
 prefix manifest: <#>
 
 manifest:content-negotiation-jsonld
   a td:TestCase ;
-  spec:requirementReference <https://solidproject.org/TR/protocol#resource-representations> ;
+  spec:requirementReference sopr:resource-representations ;
   td:reviewStatus td:accepted ;
   spec:testScript
     <https://github.com/solid/conformance-test-harness/example/protocol/content-negotiation/content-negotiation-jsonld.feature> .
 
 manifest:content-negotiation-turtle
   a td:TestCase ;
-  spec:requirementReference <https://solidproject.org/TR/protocol#resource-representations> ;
+  spec:requirementReference sopr:resource-representations ;
   td:reviewStatus td:accepted ;
   spec:testScript
     <https://github.com/solid/conformance-test-harness/example/protocol/content-negotiation/content-negotiation-turtle.feature> .
@@ -27,35 +29,35 @@ manifest:content-negotiation-rdfa
 
 manifest:writing-resource-containment
   a td:TestCase ;
-  spec:requirementReference <https://solidproject.org/TR/protocol#writing-resources> ;
+  spec:requirementReference sopr:writing-resources ;
   td:reviewStatus td:accepted ;
   spec:testScript
     <https://github.com/solid/conformance-test-harness/example/protocol/writing-resource/containment.feature> .
 
 manifest:wac-allow-access-Bob-W-public-RA
   a td:TestCase ;
-  spec:requirementReference <https://solidproject.org/TR/protocol#web-access-control> ;
+  spec:requirementReference sopr:web-access-control ;
   td:reviewStatus td:accepted ;
   spec:testScript
     <https://github.com/solid/conformance-test-harness/example/protocol/wac-allow/access-Bob-W-public-RA.feature> .
 
 manifest:wac-allow-default-Bob-W-public-RA
   a td:TestCase ;
-  spec:requirementReference <https://solidproject.org/TR/protocol#web-access-control> ;
+  spec:requirementReference sopr:web-access-control ;
   td:reviewStatus td:accepted ;
   spec:testScript
     <https://github.com/solid/conformance-test-harness/example/protocol/wac-allow/default-Bob-W-public-RA.feature> .
 
 manifest:wac-allow-access-public-R
   a td:TestCase ;
-  spec:requirementReference <https://solidproject.org/TR/protocol#web-access-control> ;
+  spec:requirementReference sopr:web-access-control ;
   td:reviewStatus td:unreviewed ;
   spec:testScript
     <https://github.com/solid/conformance-test-harness/example/protocol/wac-allow/access-public-R.feature> .
 
 manifest:storage-headers
   a td:TestCase ;
-  spec:requirementReference <https://solidproject.org/TR/protocol#server-link-storage> ;
+  spec:requirementReference sopr:server-link-storage ;
   td:reviewStatus td:unreviewed ;
   spec:testScript
     <https://github.com/solid/conformance-test-harness/example/protocol/storage/storage-headers.feature> .
@@ -65,3 +67,11 @@ manifest:parsing-tests
   td:reviewStatus td:unreviewed ;
   spec:testScript
     <https://github.com/solid/conformance-test-harness/example/parsing-tests.feature> .
+
+manifest:slash-semantics-exclude
+  a td:TestCase ;
+  spec:requirementReference sopr:server-uri-trailing-slash-distinct ,
+                              sopr:server-uri-redirect-differing ;
+  td:reviewStatus td:unreviewed ;
+  spec:testScript
+    <https://github.com/solid/conformance-test-harness/example/protocol/writing-resource/slash-semantics-exclude.feature> .

--- a/example/protocol/writing-resource/slash-semantics-exclude.feature
+++ b/example/protocol/writing-resource/slash-semantics-exclude.feature
@@ -1,0 +1,67 @@
+@parallel=false
+Feature: With and without trailing slash cannot co-exist
+
+  Background: Set up clients and paths
+    * def testContainer = rootTestContainer.reserveContainer()
+    * configure followRedirects = false
+
+  Scenario: PUT container, then try resource with same name
+    * def childContainerUrl = testContainer.url + 'foo/'
+    Given url childContainerUrl
+    And headers clients.alice.getAuthHeaders('PUT', childContainerUrl)
+    And header Content-Type = 'text/turtle'
+    When method PUT
+    Then assert responseStatus >= 200 && responseStatus < 300
+
+    * def resourceUrl = testContainer.url + 'foo'
+    Given url resourceUrl
+    And headers clients.alice.getAuthHeaders('GET', resourceUrl)
+    When method GET
+    * print response
+    Then match [301, 404, 410] contains responseStatus
+
+    Given url resourceUrl
+    And headers clients.alice.getAuthHeaders('PUT', resourceUrl)
+    And header Content-Type = 'text/plain'
+    And request "Hello"
+    When method PUT
+    * def code = responseStatus
+     # See https://www.rfc-editor.org/rfc/rfc7231.html#page-27 for why 409 or 415
+#    Then match [409, 415] contains responseStatus
+
+    Given url testContainer.url
+    And headers clients.alice.getAuthHeaders('GET', testContainer.url)
+    And header Content-Type = 'text/turtle'
+    When method GET
+    * print response
+    Then match [409, 415] contains code
+
+  Scenario: PUT resource, then try container with same name
+    * def resourceUrl = testContainer.url + 'foo'
+    Given url resourceUrl
+    And headers clients.alice.getAuthHeaders('PUT', resourceUrl)
+    And header Content-Type = 'text/plain'
+    And request "Hello"
+    When method PUT
+    Then assert responseStatus >= 200 && responseStatus < 300
+
+    * def childContainerUrl = testContainer.url + 'foo/'
+    Given url childContainerUrl
+    And headers clients.alice.getAuthHeaders('GET', childContainerUrl)
+    When method GET
+    Then match [301, 404, 410] contains responseStatus
+
+    * def childContainerUrl = testContainer.url + 'foo/'
+    Given url childContainerUrl
+    And headers clients.alice.getAuthHeaders('PUT', childContainerUrl)
+    And header Content-Type = 'text/turtle'
+    When method PUT
+     # See https://www.rfc-editor.org/rfc/rfc7231.html#page-27 for why 409 or 415
+    Then match [409, 415] contains responseStatus
+
+# TODO: Evil test to check various suffices.
+
+
+
+
+

--- a/src/test/java/org/solid/testharness/http/SolidClientProviderTest.java
+++ b/src/test/java/org/solid/testharness/http/SolidClientProviderTest.java
@@ -486,10 +486,12 @@ class SolidClientProviderTest {
         final HttpResponse<String> mockResponse = TestUtils.mockStringResponse(400, null);
 
         when(mockClient.getAsTurtle(eq(BASE_URL))).thenReturn(mockResponse);
+        when(mockClient.deleteAsync(any())).thenReturn(CompletableFuture.completedFuture(null));
 
         final SolidClientProvider solidClientProvider = new SolidClientProvider(mockClient);
         assertDoesNotThrow(() -> solidClientProvider.deleteResourceRecursively(BASE_URL));
         verify(mockClient).getAsTurtle(BASE_URL);
+        verify(mockClient, times(1)).deleteAsync(any());
         verifyNoMoreInteractions(mockClient);
     }
 
@@ -499,11 +501,13 @@ class SolidClientProviderTest {
         final HttpResponse<String> mockResponse = TestUtils.mockStringResponse(200, "NOT RDF");
 
         when(mockClient.getAsTurtle(eq(BASE_URL))).thenReturn(mockResponse);
+        when(mockClient.deleteAsync(any())).thenReturn(CompletableFuture.completedFuture(null));
 
         final SolidClientProvider solidClientProvider = new SolidClientProvider(mockClient);
         assertDoesNotThrow(() -> solidClientProvider.deleteResourceRecursively(BASE_URL));
         verify(mockClient).getAsTurtle(BASE_URL);
-        verify(mockClient, never()).deleteAsync(any());
+        verify(mockClient, times(1)).deleteAsync(any());
+        verifyNoMoreInteractions(mockClient);
     }
 
     @Test


### PR DESCRIPTION
NSS fails the slash semantics test which results in a container containing `foo` and `foo/`. When the teardown process attempts to delete them (in this order), the first delete works but when it then tries to get the contents of `foo/` this fails since it doesn't exist anymore. If we then remove the final slash and delete `foo` again this succeeds and the teardown process works. This is obviously only one way of a server failing but given that it is a known issue it allows us to keep the NSS test instance cleaner. 

The change also avoids tripping up over such cases with a null pointer exception by filtering out null responses.

The recursive delete ends up like this:
```
2022-01-17 17:26:58,412 DEBUG [org.sol.tes.htt.SolidClientProvider] (main) DELETING MEMBERS [https://solid-test-suite-alice.inrupt.net/shared-test/jwXbr9/Na2jaX/, https://solid-test-suite-alice.inrupt.net/shared-test/jwXbr9/qr0Nw9/]
2022-01-17 17:26:58,674 DEBUG [org.sol.tes.htt.SolidClientProvider] (main) DELETING MEMBERS [https://solid-test-suite-alice.inrupt.net/shared-test/jwXbr9/Na2jaX/foo, https://solid-test-suite-alice.inrupt.net/shared-test/jwXbr9/Na2jaX/foo/]
2022-01-17 17:26:58,674 DEBUG [org.sol.tes.htt.SolidClientProvider] (main) DELETE RESOURCE https://solid-test-suite-alice.inrupt.net/shared-test/jwXbr9/Na2jaX/foo
2022-01-17 17:26:58,674 DEBUG [org.sol.tes.htt.Client] (main) Deleting https://solid-test-suite-alice.inrupt.net/shared-test/jwXbr9/Na2jaX/foo
2022-01-17 17:26:59,169 ERROR [org.sol.tes.htt.SolidClientProvider] (main) Failed to get container members: java.lang.Exception: Error response=404 trying to get content for https://solid-test-suite-alice.inrupt.net/shared-test/jwXbr9/Na2jaX/foo/
2022-01-17 17:26:59,169 DEBUG [org.sol.tes.htt.Client] (main) Deleting https://solid-test-suite-alice.inrupt.net/shared-test/jwXbr9/Na2jaX/foo
2022-01-17 17:26:59,381 DEBUG [org.sol.tes.htt.SolidClientProvider] (main) DELETE RESOURCE https://solid-test-suite-alice.inrupt.net/shared-test/jwXbr9/Na2jaX/
2022-01-17 17:26:59,382 DEBUG [org.sol.tes.htt.Client] (main) Deleting https://solid-test-suite-alice.inrupt.net/shared-test/jwXbr9/Na2jaX/
2022-01-17 17:26:59,654 DEBUG [org.sol.tes.htt.SolidClientProvider] (main) DELETING MEMBERS [https://solid-test-suite-alice.inrupt.net/shared-test/jwXbr9/qr0Nw9/foo, https://solid-test-suite-alice.inrupt.net/shared-test/jwXbr9/qr0Nw9/foo/]
2022-01-17 17:26:59,654 DEBUG [org.sol.tes.htt.SolidClientProvider] (main) DELETE RESOURCE https://solid-test-suite-alice.inrupt.net/shared-test/jwXbr9/qr0Nw9/foo
2022-01-17 17:26:59,654 DEBUG [org.sol.tes.htt.Client] (main) Deleting https://solid-test-suite-alice.inrupt.net/shared-test/jwXbr9/qr0Nw9/foo
2022-01-17 17:26:59,909 ERROR [org.sol.tes.htt.SolidClientProvider] (main) Failed to get container members: java.lang.Exception: Error response=500 trying to get content for https://solid-test-suite-alice.inrupt.net/shared-test/jwXbr9/qr0Nw9/foo/
2022-01-17 17:26:59,909 DEBUG [org.sol.tes.htt.Client] (main) Deleting https://solid-test-suite-alice.inrupt.net/shared-test/jwXbr9/qr0Nw9/foo
2022-01-17 17:27:00,121 DEBUG [org.sol.tes.htt.SolidClientProvider] (main) DELETE RESOURCE https://solid-test-suite-alice.inrupt.net/shared-test/jwXbr9/qr0Nw9/
2022-01-17 17:27:00,121 DEBUG [org.sol.tes.htt.Client] (main) Deleting https://solid-test-suite-alice.inrupt.net/shared-test/jwXbr9/qr0Nw9/
2022-01-17 17:27:00,338 DEBUG [org.sol.tes.htt.SolidClientProvider] (main) DELETE RESOURCE https://solid-test-suite-alice.inrupt.net/shared-test/jwXbr9/
2022-01-17 17:27:00,339 DEBUG [org.sol.tes.htt.Client] (main) Deleting https://solid-test-suite-alice.inrupt.net/shared-test/jwXbr9/
```