### PR TITLE
Fix login-based authentication and add PKCE support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Solid Specification Conformance Test Harness
 
+## Release 1.1.3
+### Fix
+* Issues with login authentication mechanism and PKCE support.
+
 ## Release 1.1.2
 
 ### Minor changes

--- a/src/main/java/org/solid/testharness/http/HttpConstants.java
+++ b/src/main/java/org/solid/testharness/http/HttpConstants.java
@@ -61,6 +61,9 @@ public final class HttpConstants {
 
     public static final String GRANT_TYPE = "grant_type";
     public static final String CODE = "code";
+    public static final String CODE_CHALLENGE_METHOD = "code_challenge_method";
+    public static final String CODE_CHALLENGE = "code_challenge";
+    public static final String CODE_VERIFIER = "code_verifier";
     public static final String AUTHORIZATION_METHOD = "client_secret_basic";
     public static final String AUTHORIZATION_CODE_TYPE = "authorization_code";
     public static final String CLIENT_CREDENTIALS = "client_credentials";

--- a/src/test/java/org/solid/testharness/http/AuthManagerTest.java
+++ b/src/test/java/org/solid/testharness/http/AuthManagerTest.java
@@ -225,7 +225,7 @@ class AuthManagerTest {
     void authenticateLoginSessionFails() {
         when(clientRegistry.getClient(ClientRegistry.SESSION_BASED)).thenReturn(client);
         when(config.overridingTrust()).thenReturn(false);
-        setupLogin(baseUri, "test8", "BADPASSWORD", "/login/password", null);
+        setupLogin(baseUri, "test8", "BADPASSWORD1", "/login/password", null);
 
         final TestHarnessInitializationException exception = assertThrows(TestHarnessInitializationException.class,
                 () -> authManager.authenticate("test8", true));
@@ -270,7 +270,7 @@ class AuthManagerTest {
     void authenticateLoginAuthorizationFailsFormBadLogin() {
         when(clientRegistry.getClient(ClientRegistry.SESSION_BASED)).thenReturn(client);
         when(config.getOrigin()).thenReturn("https://origin/form");
-        setupLogin(baseUri, "test20", "BADPASSWORD", null, "/idp/register");
+        setupLogin(baseUri, "test20", "BADPASSWORD2", null, "/idp/register");
 
         final TestHarnessInitializationException exception = assertThrows(TestHarnessInitializationException.class,
                 () -> authManager.authenticate("test20", true));
@@ -282,7 +282,7 @@ class AuthManagerTest {
     void authenticateLoginAuthorizationFailsFormGoodLoginBadCode() {
         when(clientRegistry.getClient(ClientRegistry.SESSION_BASED)).thenReturn(client);
         when(config.getOrigin()).thenReturn("https://origin/form");
-        setupLogin(baseUri, "test21", "PASSWORD", null, "/idp/register");
+        setupLogin(baseUri, "test21", "PASSWORD302", null, "/idp/register");
 
         final TestHarnessInitializationException exception = assertThrows(TestHarnessInitializationException.class,
                 () -> authManager.authenticate("test21", true));
@@ -291,10 +291,34 @@ class AuthManagerTest {
     }
 
     @Test
+    void authenticateLoginAuthorizationFailsFormGoodLoginNoRedirect() {
+        when(clientRegistry.getClient(ClientRegistry.SESSION_BASED)).thenReturn(client);
+        when(config.getOrigin()).thenReturn("https://origin/form");
+        setupLogin(baseUri, "test22", "PASSWORD200NOLOCATION", null, "/idp/register");
+
+        final TestHarnessInitializationException exception = assertThrows(TestHarnessInitializationException.class,
+                () -> authManager.authenticate("test22", true));
+        assertEquals("Failed to follow authentication redirects", exception.getMessage());
+        verify(config, never()).getLoginEndpoint();
+    }
+
+    @Test
+    void authenticateLoginAuthorizationFailsFormGoodLoginJsonBadCode() {
+        when(clientRegistry.getClient(ClientRegistry.SESSION_BASED)).thenReturn(client);
+        when(config.getOrigin()).thenReturn("https://origin/form");
+        setupLogin(baseUri, "test23", "PASSWORD200JSON", null, "/idp/register");
+
+        final TestHarnessInitializationException exception = assertThrows(TestHarnessInitializationException.class,
+                () -> authManager.authenticate("test23", true));
+        assertEquals("Token exchange failed for grant type: authorization_code", exception.getMessage());
+        verify(config, never()).getLoginEndpoint();
+    }
+
+    @Test
     void authenticateLoginAuthorizationFailsWithoutRedirect() {
         when(clientRegistry.getClient(ClientRegistry.SESSION_BASED)).thenReturn(client);
         when(config.getOrigin()).thenReturn("https://origin/noredirect");
-        setupLogin(baseUri, "test11", "PASSWORD", "/login/password", null);
+        setupLogin(baseUri, "test11", "PASSWORD302", "/login/password", null);
 
         final TestHarnessInitializationException exception = assertThrows(TestHarnessInitializationException.class,
                 () -> authManager.authenticate("test11", true));

--- a/src/test/java/org/solid/testharness/http/AuthenticationResource.java
+++ b/src/test/java/org/solid/testharness/http/AuthenticationResource.java
@@ -105,7 +105,7 @@ public class AuthenticationResource implements QuarkusTestResourceLifecycleManag
 
         // session login fails with bad password
         wireMockServer.stubFor(WireMock.post(WireMock.urlEqualTo("/login/password"))
-                .withRequestBody(containing(HttpConstants.PASSWORD + "=BADPASSWORD"))
+                .withRequestBody(containing(HttpConstants.PASSWORD + "=BADPASSWORD1"))
                 .willReturn(WireMock.aResponse().withStatus(403)));
 
         // session login succeeds with good password
@@ -171,16 +171,30 @@ public class AuthenticationResource implements QuarkusTestResourceLifecycleManag
 
         // authorization will get bad auth response after bad login
         wireMockServer.stubFor(WireMock.post(WireMock.urlPathEqualTo("/idp/login"))
-                .withRequestBody(containing(HttpConstants.PASSWORD + "=BADPASSWORD"))
+                .withRequestBody(containing(HttpConstants.PASSWORD + "=BADPASSWORD2"))
                 .willReturn(WireMock.aResponse()
                         .withStatus(401)));
 
-        // authorization will get no code after good login
+        // authorization will get no code after good login with location header
         wireMockServer.stubFor(WireMock.post(WireMock.urlPathEqualTo("/idp/login"))
-                .withRequestBody(containing(HttpConstants.PASSWORD + "=PASSWORD"))
+                .withRequestBody(containing(HttpConstants.PASSWORD + "=PASSWORD302"))
                 .willReturn(WireMock.aResponse()
                         .withHeader(HttpConstants.HEADER_LOCATION, "https://origin/form?code=badcode")
                         .withStatus(302)));
+
+        // authorization will get no code after good login with no location in json response
+        wireMockServer.stubFor(WireMock.post(WireMock.urlPathEqualTo("/idp/login"))
+                .withRequestBody(containing(HttpConstants.PASSWORD + "=PASSWORD200NOLOCATION"))
+                .willReturn(WireMock.aResponse()
+                        .withStatus(200)));
+
+        // authorization will get no code after good login with location in json response
+        wireMockServer.stubFor(WireMock.post(WireMock.urlPathEqualTo("/idp/login"))
+                .withRequestBody(containing(HttpConstants.PASSWORD + "=PASSWORD200JSON"))
+                .willReturn(WireMock.aResponse()
+                        .withHeader(HttpConstants.HEADER_CONTENT_TYPE, HttpConstants.MEDIA_TYPE_APPLICATION_JSON)
+                        .withBody("{ \"location\" : \"https://origin/form?code=badcode\" }")
+                        .withStatus(200)));
 
         // authorization will get immediate response but no authorization code
         wireMockServer.stubFor(WireMock.get(WireMock.urlPathEqualTo("/authorization"))


### PR DESCRIPTION
CSS is changing its IDP and this uncovered 3 issues:
* The first /idp/login request failed to include Accept: text/html so might get a JSON response instead of the expected HTML page
* We assumed the response would be a 302 redirect and looked for a location header but needed to allow an alternative where the response is 200 and the body is a JSON response with the location
* The token request needed to support PKCE