### PR TITLE
Pass rdfs:comments to report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Solid Specification Conformance Test Harness
 
+## Release 1.1.5
+### Minor changes
+* When comments are linked to a test subject or a specification requirement, show them in the report.  
+
 ## Release 1.1.4
 ### Minor changes
 * When a background step is reused in multiple scenarios, ensure the log output is available in each scenario. 

--- a/USAGE.md
+++ b/USAGE.md
@@ -27,7 +27,8 @@ This is a Turtle file which describes the test subject and it's capabilities, pr
     doap:homepage <https://github.com/solid/community-server> ;
     doap:description "An open and modular implementation of the Solid specifications."@en ;
     doap:programming-language "TypeScript" ;
-    solid-test:skip "acp" .
+    solid-test:skip "acp" ;
+    rdfs:comment "Comment on the test subject"@en.
     
 <css#test-subject-release>
     doap:revision "0.9.0" ;
@@ -70,6 +71,8 @@ sources:
   # Editor's draft (fully annotated)
   - https://solidproject.org/ED/protocol
   - https://github.com/solid/specification-tests/blob/main/protocol/solid-protocol-test-manifest.ttl
+  # Additional comments on requirements (linked to requirement IRI and using rdfs:comment predicate)
+  - https://github.com/solid/specification-tests/blob/main/protocol/requirement-comments.ttl
 
   # WAC spec & manifest
   # Editor's draft (fully annotated)

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -4,6 +4,7 @@
   sources:
     - https://solidproject.org/TR/protocol
     - https://github.com/solid/conformance-test-harness/blob/main/example/protocol/solid-protocol-test-manifest.ttl
+    - https://github.com/solid/conformance-test-harness/blob/main/example/protocol/requirement-comments.ttl
 
     - https://solid.github.io/web-access-control-spec/
     - https://github.com/solid/conformance-test-harness/blob/main/example/web-access-control/web-access-control-spec.ttl
@@ -22,6 +23,7 @@
     - https://example.org/test-manifest-sample-2.ttl
     - https://example.org/specification-sample-1.ttl
     - https://example.org/specification-sample-2.ttl
+    - https://example.org/additional-comments.ttl
   target: testserver
   mappings:
     - prefix: https://example.org/test/group1

--- a/config/test-subjects.ttl
+++ b/config/test-subjects.ttl
@@ -1,10 +1,13 @@
 prefix solid-test: <https://github.com/solid/conformance-test-harness/vocab#>
 prefix doap: <http://usefulinc.com/ns/doap#>
 prefix earl: <http://www.w3.org/ns/earl#>
+prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
 <target>
     a earl:Software, earl:TestSubject ;
 #    solid-test:skip "acp" ;
     solid-test:skip "wac-allow-public", "wac", "publicagent" ;
 #    solid-test:features "acp-legacy" ;
-    doap:name "Test Subject"@en .
+    doap:name "Test Subject"@en ;
+    rdfs:comment "Example comment."@en ;
+    rdfs:comment "Another comment."@en .

--- a/example/protocol/requirement-comments.ttl
+++ b/example/protocol/requirement-comments.ttl
@@ -1,0 +1,7 @@
+prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix xsd: <http://www.w3.org/2001/XMLSchema#>
+prefix sopr: <https://solidproject.org/TR/protocol#>
+
+sopr:server-representation-turtle-jsonld rdfs:comment "Note that there is no requirement to support RDFa in a similar way, though some implementations may choose to."@en .
+sopr:server-wac rdfs:comment "Publicly accessible versions of ESS implement ACP for access control in place of WAC."@en .

--- a/example/protocol/solid-protocol-test-manifest.ttl
+++ b/example/protocol/solid-protocol-test-manifest.ttl
@@ -23,10 +23,6 @@ manifest:content-negotiation-turtle
   spec:testScript
     <https://github.com/solid/conformance-test-harness/blob/main/example/protocol/content-negotiation/content-negotiation-turtle.feature> .
 
-manifest:content-negotiation-rdfa
-  a td:TestCase ;
-  td:reviewStatus td:unreviewed .
-
 manifest:writing-resource-containment
   a td:TestCase ;
   spec:requirementReference sopr:server-put-patch-intermediate-containers ;

--- a/example/web-access-control/protected-operation/not-read-resource-default-AWC.feature
+++ b/example/web-access-control/protected-operation/not-read-resource-default-AWC.feature
@@ -1,3 +1,4 @@
+# Some of the tests below are omitted for servers not implementing WAC
 Feature: Bob cannot read an RDF resource to which he is not granted default read access via the parent
 
   Background: Create test resource with all default access except read for Bob
@@ -28,6 +29,7 @@ Feature: Bob cannot read an RDF resource to which he is not granted default read
     Then status 403
 
   @wac
+  # Not applicable if server does not implement WAC
   Scenario: Bob can PUT to the resource but gets nothing back since he cannot read
     Given request '<> <http://www.w3.org/2000/01/rdf-schema#comment> "Bob replaced it." .'
     And headers clients.bob.getAuthHeaders('PUT', resource.url)

--- a/src/main/java/org/solid/testharness/utils/DataModelBase.java
+++ b/src/main/java/org/solid/testharness/utils/DataModelBase.java
@@ -36,6 +36,7 @@ import org.eclipse.rdf4j.repository.util.Connections;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.solid.common.vocab.RDF;
+import org.solid.common.vocab.RDFS;
 
 import javax.enterprise.inject.spi.CDI;
 import javax.validation.constraints.NotNull;
@@ -139,6 +140,10 @@ public class DataModelBase {
 
     public String getAnchor() {
         return subject.getLocalName();
+    }
+
+    public List<String> getComments() {
+        return getLiteralsAsStringList(RDFS.comment);
     }
 
     protected String getIriAsString(final IRI predicate) {

--- a/src/main/resources/templates/requirement.html
+++ b/src/main/resources/templates/requirement.html
@@ -1,4 +1,4 @@
-<details id="{it.anchor}" {#if it.failed}open="open" class="failed"{/if}>
+<details id="{it.anchor}" about="{it.subject}" {#if it.failed}open="open" class="failed"{/if}>
   {#with it}
   <summary><b>Requirement:</b> {subject} <a href="{subject}"></a>
     <span>{#if coverageMode == false}{countPassed}/{/if}{countTestCases}</span>
@@ -22,6 +22,18 @@
   </dl>
   {#if statement}
   <dl><dt>Statement</dt><dd>{statement}</dd></dl>
+  {/if}
+  {#if comments}
+  <dl>
+    <dt>Additional comments</dt>
+    <dd>
+      <ul>
+      {#for comment in comments}
+        <li property="rdfs:comment">{comment}</li>
+      {/for}
+      </ul>
+    </dd>
+  </dl>
   {/if}
   {/with}
   {#insert/}

--- a/src/main/resources/templates/test-subject.html
+++ b/src/main/resources/templates/test-subject.html
@@ -16,5 +16,17 @@
         (<time datatype="xsd:dateTime" datetime="{releaseDate}" content="{releaseDate}" property="doap:created">{releaseDateAsDate}</time>)
       </dd>
     </dl>
+    {#if comments}
+    <dl>
+      <dt>Additional comments</dt>
+      <dd>
+        <ul>
+          {#for comment in comments}
+          <li property="rdfs:comment">{comment}</li>
+          {/for}
+        </ul>
+      </dd>
+    </dl>
+    {/if}
   </div>
 </section>

--- a/src/test/java/org/solid/testharness/config/TestSubjectSetupTest.java
+++ b/src/test/java/org/solid/testharness/config/TestSubjectSetupTest.java
@@ -72,7 +72,7 @@ public class TestSubjectSetupTest {
         final TargetServer targetServer = testSubject.getTargetServer();
         assertNotNull(targetServer);
         assertEquals(subject, targetServer.getSubject());
-        assertEquals(13, targetServer.size());
+        assertEquals(15, targetServer.size());
     }
 
     @Test

--- a/src/test/java/org/solid/testharness/utils/DataModelBaseTest.java
+++ b/src/test/java/org/solid/testharness/utils/DataModelBaseTest.java
@@ -71,24 +71,24 @@ class DataModelBaseTest extends AbstractDataModelTests {
 
     @Test
     void getModel() {
-        assertEquals(13, dataModelBase.getModel().size());
+        assertEquals(15, dataModelBase.getModel().size());
     }
 
     @Test
     void sizeShallow() {
-        assertEquals(13, dataModelBase.size());
+        assertEquals(15, dataModelBase.size());
     }
 
     @Test
     void sizeDeep() {
         final DataModelBase deepModel = new DataModelBase(iri(NS, "test"), DataModelBase.ConstructMode.DEEP);
-        assertEquals(18, deepModel.size());
+        assertEquals(20, deepModel.size());
     }
 
     @Test
     void sizeList() {
         final DataModelBase listModel = new DataModelBase(iri(NS, "test"), DataModelBase.ConstructMode.DEEP_WITH_LISTS);
-        assertEquals(20, listModel.size());
+        assertEquals(22, listModel.size());
     }
 
     @Test
@@ -294,6 +294,19 @@ class DataModelBaseTest extends AbstractDataModelTests {
     @Test
     void getAnchor() {
         assertEquals("test", dataModelBase.getAnchor());
+    }
+
+    @Test
+    void getComments() {
+        final List<String> comments = dataModelBase.getComments();
+        assertEquals(2, comments.size());
+        assertTrue(comments.get(0).contains("Comment "));
+    }
+
+    @Test
+    void getCommentsNone() {
+        final DataModelBase reqModel = new DataModelBase(iri(NS, "requirement"));
+        assertEquals(0, reqModel.getComments().size());
     }
 
     class TestClass extends DataModelBase {

--- a/src/test/java/org/solid/testharness/utils/DataRepositoryTest.java
+++ b/src/test/java/org/solid/testharness/utils/DataRepositoryTest.java
@@ -343,7 +343,7 @@ class DataRepositoryTest {
         final DataRepository dataRepository = new DataRepository();
         final URL url = Path.of("src/test/resources/config/config-sample.ttl").normalize().toUri().toURL();
         dataRepository.load(url);
-        assertEquals(25, dataRepositorySize(dataRepository));
+        assertEquals(27, dataRepositorySize(dataRepository));
     }
 
     @Test

--- a/src/test/resources/config/config-sample.ttl
+++ b/src/test/resources/config/config-sample.ttl
@@ -16,7 +16,9 @@
     doap:description "DESCRIPTION"@en;
     doap:programming-language "LANG" ;
     solid-test:skip "acp" ;
-    solid-test:features "acp-legacy" .
+    solid-test:features "acp-legacy" ;
+    rdfs:comment "This is a comment about this server"@en ;
+    rdfs:comment "This is a second comment about this server"@en .
 
 <testserver#test-subject-release>
     doap:name "VERSION NAME";

--- a/src/test/resources/discovery/additional-comments.ttl
+++ b/src/test/resources/discovery/additional-comments.ttl
@@ -1,0 +1,7 @@
+prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix xsd: <http://www.w3.org/2001/XMLSchema#>
+
+<https://example.org/specification1#spec1> rdfs:comment "This is a comment about this requirement"@en .
+<https://example.org/specification1#spec1> rdfs:comment "This is a second comment about this requirement"@en .
+

--- a/src/test/resources/reporting/datamodelbase-testing-feature.ttl
+++ b/src/test/resources/reporting/datamodelbase-testing-feature.ttl
@@ -1,6 +1,7 @@
 prefix xsd: <http://www.w3.org/2001/XMLSchema#>
 prefix earl: <http://www.w3.org/ns/earl#>
 prefix ex: <https://example.org/>
+prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
 ex:test
     a earl:Software, earl:TestSubject ;
@@ -13,7 +14,9 @@ ex:test
     ex:hasDateTime "2021-04-08T12:30:00.000Z"^^xsd:dateTime ;
     ex:hasBNode [ ex:hasString "string"; ex:hasDateTime "2021-07-09T00:00:00.000Z"^^xsd:dateTime];
     ex:hasTest ex:test1 ;
-    ex:hasSteps (ex:step1 ex:step2) .
+    ex:hasSteps (ex:step1 ex:step2) ;
+    rdfs:comment "Comment 1"@en ;
+    rdfs:comment "Comment 2"@en .
 ex:test1 a earl:TestCase .
 ex:step1 a earl:Step .
 ex:step2 a earl:Step .


### PR DESCRIPTION
Allow comments to be added to test-subjects to add details about the implementation. Also allow the addition of an extra source file that will use requirement IRIs to add comments at the requirement level. 