### PR TITLE
URL encode client id as per OAuth 2.0 RFC 6749 Section 2.3.1

### DIFF
--- a/src/main/java/org/solid/testharness/http/Client.java
+++ b/src/main/java/org/solid/testharness/http/Client.java
@@ -41,12 +41,14 @@ import jakarta.validation.constraints.NotNull;
 import java.net.CookieHandler;
 import java.net.CookieManager;
 import java.net.URI;
+import java.net.URLEncoder;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandler;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.net.http.HttpTimeoutException;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -169,8 +171,10 @@ public class Client {
                                      final String clientId, final String clientSecret,
                                      final Map<Object, Object> tokenRequestData) {
         this.tokenEndpoint = oidcConfig.getTokenEndpoint();
-        this.authHeader = HttpConstants.PREFIX_BASIC +
-                Base64.getEncoder().encodeToString((clientId + ':' + clientSecret).getBytes());
+        this.authHeader = HttpConstants.PREFIX_BASIC + Base64.getEncoder().encodeToString((
+                URLEncoder.encode(clientId, StandardCharsets.UTF_8) + ':'
+                        + URLEncoder.encode(clientSecret, StandardCharsets.UTF_8)
+        ).getBytes(StandardCharsets.UTF_8));
         this.tokenRequestData = tokenRequestData;
     }
 


### PR DESCRIPTION
This is the change from https://github.com/solid-contrib/conformance-test-harness/pull/661 written by @elf-pavlik